### PR TITLE
feat(homelab): initial commit with working terraform for vms, Kuberne…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+.qodo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# Homelab
-Personal Sandbox
+# 🏠 Homelab
+
+## Introduction
+This repository showcases my personal homelab setup, built for high availability, automation, and scalability. The homelab serves as both a learning environment and a space for experimentation and fun.
+
+My setup consists of a single physical machine hosting multiple Arch Linux virtual machines (VMs), provisioned using Terraform. These VMs form the foundation of my Kubernetes (k8s) cluster, which powers various applications and services. While this repository contains configurations for services running within the Kubernetes cluster, configurations for system-level services on the physical machine (such as NFS) are not included.
+
+Managing my own infrastructure provides valuable hands-on experience, making me responsible for the entire application lifecycle—from deployment and maintenance to security, scalability, and backup strategies.
+
+## Infrastructure
+### Virtualization & Provisioning
+- **Hypervisor:** Single physical machine running multiple Arch Linux VMs
+- **Provisioning:** Terraform
+- **Networking:** nftables
+- **Storage:** NFS for persistent volumes (planned migration to Longhorn)
+- **Secret Management:** External source (planned migration to Vault)
+
+### Kubernetes Cluster
+- **Control Plane:** Multiple k8s master nodes
+- **Worker Nodes:** Multiple k8s worker nodes to handle load
+- **Networking:** Cilium (CNI)
+- **Ingress Controller:** Traefik
+- **Certificate Management:** cert-manager
+- **Storage:** Persistent Volumes (NFS, future migration to Longhorn)
+- **Secrets:** External storage (future migration to HashiCorp Vault)
+
+## 🚀 Installed Apps & Tools
+The following services are deployed on top of Kubernetes:
+- **Vaultwarden:** Secure password management
+- **PathfinderWiki:** MediaWiki-based wiki  (nginx, php-fpm, MariaDB)
+- **Ollama & OpenWebUI:** AI-related services for local LLM hosting and interaction
+- **n8n:** Workflow automation tool, primarily used for AI workload orchestration
+
+### Backup Strategy
+- All critical services are backed up to dedicated NFS Persistent Volumes (PVs)
+
+## Future Enhancements
+
+**Object Store:** Deploying a Ceph cluster on VMs to provide distributed object storage, improving scalability and redundancy.
+
+**Monitoring:** Implementing Grafana, Loki, and Mimir for centralized monitoring, logging, and metrics collection.
+
+**Storage Improvements:** Transitioning from NFS-based persistent volumes to Longhorn for better resilience and dynamic volume provisioning.
+
+**Secret Management:** Integrating HashiCorp Vault to centralize and securely manage application secrets.
+
+**Automation Enhancements:** Expanding n8n workflows to streamline automation tasks, reducing manual intervention and improving efficiency.
+
+**Redis Cluster:** Deploying a Redis cluster for high-availability caching and improved performance of applications.
+
+**MariaDB Galera Cluster:** Implementing a MariaDB Galera Cluster for synchronous multi-master database replication, ensuring fault tolerance and high availability.
+
+**PostgreSQL High Availability:** Setting up a highly available PostgreSQL cluster with replication and failover mechanisms for improved database resilience.
+
+## Repository Structure
+```
+/
+├── terraform/       # Infrastructure as Code for VM provisioning
+│   ├── k8s/         # Kubernetes-related infrastructure
+│   └── ceph/        # Ceph deployment configurations
+├── apps/            # Kubernetes manifests and configurations for apps running on top of infrastructure
+├── monitoring/      # Kubernetes manifests and configurations for monitoring
+└── infrastructure/  # Kubernetes manifests and configurations for k8s infra components
+```
+
+## Contact
+For any inquiries, discussions, or collaboration, feel free to reach out!
+

--- a/apps/base/n8n/00-namespace.yaml
+++ b/apps/base/n8n/00-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: n8n

--- a/apps/base/n8n/09-ingress-route.yaml
+++ b/apps/base/n8n/09-ingress-route.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: n8n-ingress
+  namespace: n8n
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`n8n.k8s.tommahs.nl`)
+      priority: 10
+      services:
+        - kind: Service
+          name: n8n
+          namespace: n8n
+          passHostHeader: true
+          port: 5678
+          responseForwarding:
+            flushInterval: 1ms
+  tls:
+    secretName: n8n-k8s-tommahs-nl-tls

--- a/apps/base/n8n/10-certificate.yaml
+++ b/apps/base/n8n/10-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: n8n-k8s-tommahs-nl-tls
+  namespace: n8n
+spec:
+  secretName: n8n-k8s-tommahs-nl-tls
+  dnsNames:
+    - n8n.k8s.tommahs.nl
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/apps/base/n8n/10-ingress-middleware.yaml
+++ b/apps/base/n8n/10-ingress-middleware.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-to-https
+  namespace: n8n
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true

--- a/apps/base/n8n/base/03-deployment.yaml
+++ b/apps/base/n8n/base/03-deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service: n8n
+  name: n8n
+  namespace: n8n
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: n8n
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        service: n8n
+    spec:
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.36
+          command: ["sh", "-c", "mkdir /data && chown 1000:1000 /data"]
+      containers:
+        - command:
+            - /bin/sh
+          args:
+            - -c
+            - sleep 5; n8n start
+          env:
+            - name: DB_TYPE
+              value: postgresdb
+            - name: DB_POSTGRESDB_HOST
+              value: postgres-service.n8n.svc.cluster.local
+            - name: DB_POSTGRESDB_PORT
+              value: "5432"
+            - name: DB_POSTGRESDB_DATABASE
+              value: n8n
+            - name: DB_POSTGRESDB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_NON_ROOT_USER
+            - name: DB_POSTGRESDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_NON_ROOT_PASSWORD
+            - name: N8N_PROTOCOL
+              value: http
+            - name: N8N_PORT
+              value: "5678"
+            # BEGIN ISOLATION
+            - name: N8N_DIAGNOSTICS_ENABLED
+              value: "false"
+            - name: N8N_VERSION_NOTIFICATIONS_ENABLED
+              value: "false"
+            - name: N8N_TEMPLATES_ENABLED
+              value: "false"
+            - name: EXTERNAL_FRONTEND_HOOKS_URLS
+              value: ""
+            - name: N8N_DIAGNOSTICS_CONFIG_FRONTEND
+              value: ""
+            - name: N8N_DIAGNOSTICS_CONFIG_BACKEND
+              value: ""
+            # END ISOLATION
+            # START override webhooks as we are behind proxy
+            - name: WEBHOOK_URL
+              value: "https://n8n.k8s.tommahs.nl"
+            # END override webhook
+            # expose prometheus metrics
+            - name: N8N_METRICS
+              value: "true"
+            - name: N8N_METRICS_INCLUDE_QUEUE_METRICS
+              value: "true"
+          image: n8nio/n8n
+          name: n8n
+          ports:
+            - containerPort: 5678
+          resources:
+            requests:
+              memory: "250Mi"
+            limits:
+              memory: "500Mi"
+      restartPolicy: Always
+      volumes:
+        - name: n8n-secret
+          secret:
+            secretName: n8n-secret
+        - name: postgres-secret
+          secret:
+            secretName: postgres-secret

--- a/apps/base/n8n/base/04-service.yaml
+++ b/apps/base/n8n/base/04-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: n8n
+  name: n8n
+  namespace: n8n
+spec:
+  selector:
+    service: n8n
+  # type: LoadBalancer
+  ports:
+    - protocol: TCP
+      name: "5678"
+      port: 5678
+      targetPort: 5678

--- a/apps/base/n8n/kustomization.yaml
+++ b/apps/base/n8n/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: n8n
+resources:
+  - 00-namespace.yaml
+  - base/03-deployment.yaml
+  - base/04-service.yaml
+  - postgres/02-config-map.yaml
+  - postgres/03-deployment.yaml
+  - postgres/04-service.yaml
+  - 09-ingress-route.yaml
+  - 10-certificate.yaml
+  - 10-ingress-middleware.yaml
+  

--- a/apps/base/n8n/postgres/02-config-map.yaml
+++ b/apps/base/n8n/postgres/02-config-map.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: init-data
+  namespace: n8n
+data:
+  init-data.sh: |
+    #!/bin/bash
+    set -e;
+    if [ -n "${POSTGRES_NON_ROOT_USER:-}" ] && [ -n "${POSTGRES_NON_ROOT_PASSWORD:-}" ]; then
+    	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    		CREATE USER "${POSTGRES_NON_ROOT_USER}" WITH PASSWORD '${POSTGRES_NON_ROOT_PASSWORD}';
+    		GRANT ALL PRIVILEGES ON DATABASE ${POSTGRES_DB} TO "${POSTGRES_NON_ROOT_USER}";
+    	EOSQL
+    else
+    	echo "SETUP INFO: No Environment variables given!"
+    fi

--- a/apps/base/n8n/postgres/03-deployment.yaml
+++ b/apps/base/n8n/postgres/03-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    service: postgres-n8n
+  name: postgres
+  namespace: n8n
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: postgres-n8n
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        service: postgres-n8n
+    spec:
+      containers:
+        - image: postgres:11
+          name: postgres
+          resources:
+            limits:
+              cpu: "4"
+              memory: 4Gi
+            requests:
+              cpu: "1"
+              memory: 2Gi
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: init-data
+              mountPath: /docker-entrypoint-initdb.d/init-n8n-user.sh
+              subPath: init-data.sh
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata      
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              value: n8n
+            - name: POSTGRES_NON_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_NON_ROOT_USER
+            - name: POSTGRES_NON_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-secret
+                  key: POSTGRES_NON_ROOT_PASSWORD
+            - name:   POSTGRES_HOST
+              value: postgres-service
+            - name: POSTGRES_PORT
+              value: '5432'
+      restartPolicy: Always
+      volumes:
+        - name: postgres-secret
+          secret:
+            secretName: postgres-secret
+        - name: init-data
+          configMap:
+            name: init-data
+            defaultMode: 0744

--- a/apps/base/n8n/postgres/04-service.yaml
+++ b/apps/base/n8n/postgres/04-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    service: postgres-n8n
+  name: postgres-service
+  namespace: n8n
+spec:
+  clusterIP: None
+  ports:
+    - name: "5432"
+      port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    service: postgres-n8n

--- a/apps/base/ollama/00-namespace.yaml
+++ b/apps/base/ollama/00-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollama

--- a/apps/base/ollama/00-storage-class.yaml
+++ b/apps/base/ollama/00-storage-class.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ollama-expandable
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openwebui-expandable
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain
+allowVolumeExpansion: true

--- a/apps/base/ollama/01-pv.yaml
+++ b/apps/base/ollama/01-pv.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ollama-pv
+  namespace: ollama
+spec:
+  capacity:
+    storage: 40Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ollama-expandable
+  nfs:
+    path: /data/nfs/ollama/ollama/0
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: openwebui-pv
+  namespace: ollama
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: openwebui-expandable
+  nfs:
+    path: /data/nfs/ollama/openwebui/0
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1

--- a/apps/base/ollama/02-pvc.yaml
+++ b/apps/base/ollama/02-pvc.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-pvc
+  namespace: ollama
+spec:
+  storageClassName: ollama-expandable
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 40Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openwebui-pvc
+  namespace: ollama
+spec:
+  storageClassName: openwebui-expandable
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Gi

--- a/apps/base/ollama/03-deployment.yaml
+++ b/apps/base/ollama/03-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          ports:
+            - containerPort: 11434
+          volumeMounts:
+            - name: ollama-storage
+              mountPath: /root/.ollama
+      nodeSelector:
+        ramtype: ramtype
+      volumes:
+        - name: ollama-storage
+          persistentVolumeClaim:
+            claimName: ollama-pvc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: open-webui
+  namespace: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: open-webui
+  template:
+    metadata:
+      labels:
+        app: open-webui
+    spec:
+      containers:
+        - name: open-webui
+          image: ghcr.io/open-webui/open-webui:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: OLLAMA_BASE_URL
+              value: "http://ollama-service.ollama"
+          volumeMounts:
+            - name: open-webui-storage
+              mountPath: /app/backend/data
+      volumes:
+        - name: open-webui-storage
+          persistentVolumeClaim:
+            claimName: openwebui-pvc

--- a/apps/base/ollama/04-service.yaml
+++ b/apps/base/ollama/04-service.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama-service
+  namespace: ollama
+spec:
+  selector:
+    app: ollama
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 11434
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-webui-service
+  namespace: ollama
+spec:
+  selector:
+    app: open-webui
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: ClusterIP

--- a/apps/base/ollama/05-ingress.yaml
+++ b/apps/base/ollama/05-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: open-webui-ingress
+  namespace: ollama
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`open-webui.k8s.tommahs.nl`)
+      priority: 10
+      middlewares:
+        - name: redirect-to-https
+      services:
+        - kind: Service
+          name: open-webui-service
+          namespace: ollama
+          passHostHeader: true
+          port: 80
+          responseForwarding:
+            flushInterval: 1ms
+  tls:
+    secretName: open-webui-k8s-tommahs-nl-tls

--- a/apps/base/ollama/06-ingress-middleware.yaml
+++ b/apps/base/ollama/06-ingress-middleware.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-to-https
+  namespace: ollama
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true

--- a/apps/base/ollama/10-certificate.yaml
+++ b/apps/base/ollama/10-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: open-webui-k8s-tommahs-nl-tls
+  namespace: ollama
+spec:
+  secretName: open-webui-k8s-tommahs-nl-tls
+  dnsNames:
+    - open-webui.k8s.tommahs.nl
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/apps/base/ollama/kustomization.yaml
+++ b/apps/base/ollama/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ollama
+resources:
+  - 00-namespace.yaml
+  - 00-storage-class.yaml
+  - 01-pv.yaml
+  - 02-pvc.yaml
+  - 03-deployment.yaml
+  - 04-service.yaml
+  - 05-ingress.yaml
+  - 06-ingress-middleware.yaml
+  - 10-certificate.yaml

--- a/apps/base/pathfinderwiki/09-ingress-route.yaml
+++ b/apps/base/pathfinderwiki/09-ingress-route.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: pathfinderwiki-ingress
+  namespace: pathfinderwiki
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`pathfinderwiki.tommahs.nl`)
+      priority: 10
+      services:
+        - kind: Service
+          name: pathfinderwiki-nginx-service
+          namespace: pathfinderwiki
+          passHostHeader: true
+          port: 80
+          responseForwarding:
+            flushInterval: 1ms
+  tls:
+    secretName: pathfinderwiki-tls

--- a/apps/base/pathfinderwiki/10-certificate.yaml
+++ b/apps/base/pathfinderwiki/10-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pathfinderwiki-tls
+  namespace: pathfinderwiki
+spec:
+  secretName: pathfinderwiki-tls
+  dnsNames:
+    - pathfinderwiki.tommahs.nl
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/apps/base/pathfinderwiki/10-ingress-middleware.yaml
+++ b/apps/base/pathfinderwiki/10-ingress-middleware.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-to-https
+  namespace: pathfinderwiki
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true

--- a/apps/base/pathfinderwiki/11-troubleshoot.yaml
+++ b/apps/base/pathfinderwiki/11-troubleshoot.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: debug-tools
+  namespace: pathfinderwiki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: debug-tools
+  template:
+    metadata:
+      labels:
+        app: debug-tools
+    spec:
+      containers:
+        - name: debug-tools
+          image: curlimages/curl:latest
+          command: ["sh", "-c", "sleep infinity"]
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
+            requests:
+              cpu: "50m"
+              memory: "64Mi"

--- a/apps/base/pathfinderwiki/base/00-namespace.yaml
+++ b/apps/base/pathfinderwiki/base/00-namespace.yaml
@@ -1,0 +1,6 @@
+---
+# 00-namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pathfinderwiki

--- a/apps/base/pathfinderwiki/base/01-pathfinderwiki-pv.yaml
+++ b/apps/base/pathfinderwiki/base/01-pathfinderwiki-pv.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pathfinderwiki-content-pv
+  namespace: pathfinderwiki
+spec:
+  capacity:
+    storage: 20Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: pathfinderwiki-content
+  nfs:
+    path: /data/nfs/pathfinderwiki/pathfinderwiki-content
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1

--- a/apps/base/pathfinderwiki/base/01-role.yaml
+++ b/apps/base/pathfinderwiki/base/01-role.yaml
@@ -1,0 +1,11 @@
+---
+# RBAC for secret rotation
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-manager
+  namespace: pathfinderwiki
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create", "update", "patch"]

--- a/apps/base/pathfinderwiki/base/01-service-account.yaml
+++ b/apps/base/pathfinderwiki/base/01-service-account.yaml
@@ -1,0 +1,12 @@
+---
+# base/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pathfinderwiki
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mariadb-vault-auth
+  namespace: pathfinderwiki

--- a/apps/base/pathfinderwiki/base/01-storage-class.yaml
+++ b/apps/base/pathfinderwiki/base/01-storage-class.yaml
@@ -1,0 +1,9 @@
+---
+# 01-storage-class.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: pathfinderwiki-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain

--- a/apps/base/pathfinderwiki/base/01-vault-configmap.yaml
+++ b/apps/base/pathfinderwiki/base/01-vault-configmap.yaml
@@ -1,0 +1,45 @@
+---
+# 07-vault-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-db-config
+  namespace: pathfinderwiki
+data:
+  init-vault.sh: |
+    #!/bin/sh
+    # Enable database secrets engine
+    vault secrets enable -path=database database
+    
+    # Create policy for secret rotation
+    vault policy write pathfinderwiki-mariadb-policy - <<EOF
+    path "database/creds/pathfinderwiki-mariadb-role" {
+      capabilities = ["read"]
+    }
+    EOF
+
+    # Configure Kubernetes auth role
+    vault write auth/kubernetes/role/pathfinderwiki-mariadb-role \
+      bound_service_account_names=vault-auth \
+      bound_service_account_namespaces=pathfinderwiki \
+      policies=pathfinderwiki-mariadb-policy \
+      ttl=1h
+
+    # Configure database secret rotation
+    vault write database/config/pathfinderwiki-mariadb \
+      plugin_name=mysql-database-plugin \
+      connection_url="{{username}}:{{password}}@tcp(pathfinderwiki-mariadb-cluster-primary.pathfinderwiki.svc.cluster.local:3306)/" \
+      allowed_roles="pathfinderwiki-mariadb-role" \
+      username="root" \
+      password="${ROOT_PASSWORD}"
+
+    # Create role for password rotation
+    vault write database/roles/pathfinderwiki-mariadb-role \
+      db_name=pathfinderwiki-mariadb \
+      creation_statements="CREATE USER IF NOT EXISTS 'pathfinderwiki'@'%' IDENTIFIED BY '{{password}}'; \
+        GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, \
+        CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, \
+        CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER \
+        ON pathfinderwiki.* TO 'pathfinderwiki'@'%';" \
+      default_ttl="720h" \
+      max_ttl="720h"

--- a/apps/base/pathfinderwiki/base/02-pathfinder-pvc.yaml
+++ b/apps/base/pathfinderwiki/base/02-pathfinder-pvc.yaml
@@ -1,0 +1,14 @@
+---
+# PVC for wiki content (if not already created)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pathfinderwiki-content-pvc
+  namespace: pathfinderwiki
+spec:
+  storageClassName: pathfinderwiki-content
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi

--- a/apps/base/pathfinderwiki/base/02-role-binding.yaml
+++ b/apps/base/pathfinderwiki/base/02-role-binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-manager
+  namespace: pathfinderwiki
+subjects:
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: pathfinderwiki
+roleRef:
+  kind: Role
+  name: secret-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/apps/base/pathfinderwiki/jobs/09-mariadb-restore.yaml
+++ b/apps/base/pathfinderwiki/jobs/09-mariadb-restore.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pathfinderwiki-mariadb-restore
+  namespace: pathfinderwiki
+spec:
+  template:
+    spec:
+      containers:
+      - name: mariadb-restore
+        image: mariadb:11.7.2-noble
+        command:
+        - /bin/bash
+        - -c
+        - |
+          # Wait for MariaDB to be fully initialized
+          until mariadb -h pathfinderwiki-mariadb-service -u $MARIADB_USER -p$MARIADB_PASSWORD -e "SELECT 1"; do
+            echo "Waiting for MariaDB to be ready..."
+            sleep 5
+          done
+          
+          echo "MariaDB is ready. Starting restore..."
+          
+          # For .sql backup file
+          #MARIADB -h pathfinderwiki-mariadb-service -u $MARIADB_USER -p$MARIADB_PASSWORD $MARIADB_DATABASE < /backup/dump.sql
+          
+          # For compressed backup
+          gunzip -c /backup/pathfinderwiki.sql.gz | mariadb -h pathfinderwiki-mariadb-service -u $MARIADB_USER -p$MARIADB_PASSWORD $MARIADB_DATABASE
+          
+          echo "Restore completed successfully!"
+        env:
+        - name: MARIADB_USER
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-secrets
+              key: username
+        - name: MARIADB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-secrets
+              key: password
+        - name: MARIADB_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-secrets
+              key: database
+        volumeMounts:
+        - name: backup-volume
+          mountPath: /backup
+      volumes:
+      - name: backup-volume
+        persistentVolumeClaim:
+          claimName: pathfinderwiki-mariadb-backup-pvc
+      restartPolicy: OnFailure

--- a/apps/base/pathfinderwiki/jobs/10-mariadb-backup.yaml
+++ b/apps/base/pathfinderwiki/jobs/10-mariadb-backup.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pathfinderwiki-mariadb-backup-job
+  namespace: pathfinderwiki
+spec:
+  template:
+    spec:
+      containers:
+      - name: mariadb-dump
+        image: mariadb:11.7.2-noble
+        command:
+          - /bin/bash
+          - -c
+          - |
+            # Wait for MariaDB to be fully initialized
+            until mariadb -h pathfinderwiki-mariadb-service -u $MARIADB_USER -p$MARIADB_PASSWORD -e "SELECT 1"; do
+              echo "Waiting for MariaDB to be ready..."
+              sleep 5
+            done
+            
+            echo "MariaDB is ready. Starting backup procedure..."
+            
+            
+            # For compressed backup
+            mariadb-dump -h pathfinderwiki-mariadb-service -u $MARIADB_USER -p$MARIADB_PASSWORD $MARIADB_DATABASE | gzip > /backup/pathfinderwiki_$(date +\%Y-\%m-\%d).sql.gz
+
+            echo "Backup completed successfully!"
+        env:
+        - name: MARIADB_USER
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-secrets
+              key: username
+        - name: MARIADB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-secrets
+              key: password
+        - name: MARIADB_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: mariadb-secrets
+              key: database
+        volumeMounts:
+        - name: backup-volume
+          mountPath: /backup
+      volumes:
+      - name: backup-volume
+        persistentVolumeClaim:
+          claimName: pathfinderwiki-mariadb-backup-pvc
+      restartPolicy: OnFailure

--- a/apps/base/pathfinderwiki/jobs/10-mariadb-cronjob-backup.yaml
+++ b/apps/base/pathfinderwiki/jobs/10-mariadb-cronjob-backup.yaml
@@ -1,0 +1,57 @@
+---
+# 08-secret-rotation-job.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pathfinderwiki-mariadb-cronjob-backup
+  namespace: pathfinderwiki
+spec:
+  schedule: "0 2 * * *" # Runs every day at 0200
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: mariadb-dump
+            image: mariadb:11.7.2-noble
+            command:
+              - /bin/bash
+              - -c
+              - |
+                # Wait for MariaDB to be fully initialized
+                until mariadb -h pathfinderwiki-mariadb-service -u $MARIADB_USER -p$MARIADB_PASSWORD -e "SELECT 1"; do
+                  echo "Waiting for MariaDB to be ready..."
+                  sleep 5
+                done
+                
+                echo "MariaDB is ready. Starting backup procedure..."
+                
+                
+                # For compressed backup
+                mariadb-dump -h pathfinderwiki-mariadb-service -u $MARIADB_USER -p$MARIADB_PASSWORD $MARIADB_DATABASE | gzip > /backup/pathfinderwiki_$(date +\%Y-\%m-\%d).sql.gz
+
+                echo "Backup completed successfully!"
+            env:
+            - name: MARIADB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: username
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: password
+            - name: MARIADB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: database
+            volumeMounts:
+            - name: backup-volume
+              mountPath: /backup
+          volumes:
+          - name: backup-volume
+            persistentVolumeClaim:
+              claimName: pathfinderwiki-mariadb-backup-pvc
+          restartPolicy: OnFailure

--- a/apps/base/pathfinderwiki/kustomization.yaml
+++ b/apps/base/pathfinderwiki/kustomization.yaml
@@ -1,0 +1,28 @@
+---
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pathfinderwiki
+resources:
+  - base/00-namespace.yaml
+  - base/01-pathfinderwiki-pv.yaml
+  - base/01-role.yaml
+  - base/01-service-account.yaml
+  - base/01-storage-class.yaml
+  - base/01-vault-configmap.yaml
+  - base/02-pathfinder-pvc.yaml
+  - base/02-role-binding.yaml
+  - mariadb/01-mariadb-pv.yaml
+  - mariadb/02-mariadb-pvc.yaml
+  - mariadb/03-deployment.yaml
+  - mariadb/07-service.yaml
+  - php-fpm/03-phpfpm-deployment.yaml
+  - php-fpm/04-phpfpm-service.yaml
+  - nginx/02-nginx-configmap.yaml
+  - nginx/03-nginx-deployment.yaml
+  - nginx/04-nginx-service.yaml
+  - 09-ingress-route.yaml
+  - 10-certificate.yaml
+  - 10-ingress-middleware.yaml
+  - jobs/09-mariadb-restore.yaml
+  - jobs/10-mariadb-cronjob-backup.yaml

--- a/apps/base/pathfinderwiki/mariadb/01-mariadb-pv.yaml
+++ b/apps/base/pathfinderwiki/mariadb/01-mariadb-pv.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pathfinderwiki-mariadb-data-0-pv
+  namespace: pathfinderwiki
+spec:
+  capacity:
+    storage: 20Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: pathfinderwiki-mariadb-data-storage
+  nfs:
+    path: /data/nfs/pathfinderwiki/mariadb-data/0
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pathfinderwiki-mariadb-backup-pv
+  namespace: pathfinderwiki
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: pathfinderwiki-mariadb-backup-storage
+  nfs:
+    path: /data/nfs/pathfinderwiki/mariadb-backup
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1

--- a/apps/base/pathfinderwiki/mariadb/02-mariadb-pvc.yaml
+++ b/apps/base/pathfinderwiki/mariadb/02-mariadb-pvc.yaml
@@ -1,0 +1,28 @@
+---
+# 03-backup-pvc.yaml // pathfinderwiki-mariadb-data
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pathfinderwiki-mariadb-data-0-pvc
+  namespace: pathfinderwiki
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: pathfinderwiki-mariadb-data-storage
+  resources:
+    requests:
+      storage: 20Gi
+---
+# 03-backup-pvc.yaml // pathfinderwiki-mariadb-backup
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pathfinderwiki-mariadb-backup-pvc
+  namespace: pathfinderwiki
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: pathfinderwiki-mariadb-backup-storage
+  resources:
+    requests:
+      storage: 50Gi

--- a/apps/base/pathfinderwiki/mariadb/03-deployment.yaml
+++ b/apps/base/pathfinderwiki/mariadb/03-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pathfinderwiki-mariadb
+  namespace: pathfinderwiki
+spec:
+  serviceName: pathfinderwiki-mariadb-service
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pathfinderwiki-mariadb
+  template:
+    metadata:
+      labels:
+        app: pathfinderwiki-mariadb
+    spec:
+      containers:
+        - name: mariadb
+          image: mariadb:11.7.2-noble
+          env:
+            - name: MARIADB_RANDOM_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: randomrootpassword
+            - name: MARIADB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: username
+            - name: MARIADB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: password
+            - name: MARIADB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: database
+          ports:
+            - containerPort: 3306

--- a/apps/base/pathfinderwiki/mariadb/07-service.yaml
+++ b/apps/base/pathfinderwiki/mariadb/07-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pathfinderwiki-mariadb-service
+  namespace: pathfinderwiki
+spec:
+  selector:
+    app: pathfinderwiki-mariadb
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306

--- a/apps/base/pathfinderwiki/nginx/02-nginx-configmap.yaml
+++ b/apps/base/pathfinderwiki/nginx/02-nginx-configmap.yaml
@@ -1,0 +1,87 @@
+---
+# ConfigMap for nginx.conf
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pathfinderwiki-nginx-config
+  namespace: pathfinderwiki
+data:
+  nginx.conf: |
+    user nginx;
+    worker_processes auto;
+    pid /run/nginx.pid;
+    include /etc/nginx/modules-enabled/*.conf;
+    events {
+      worker_connections 768;
+    }
+    http {
+      limit_req_zone $binary_remote_addr zone=one:10m rate=5r/s;
+      sendfile on;
+      tcp_nopush on;
+      tcp_nodelay on;
+      keepalive_timeout 65;
+      types_hash_max_size 2048;
+      include /etc/nginx/mime.types;
+      default_type application/octet-stream;
+      ssl_prefer_server_ciphers on;
+      access_log /var/log/nginx/access.log;
+      error_log /var/log/nginx/error.log;
+      gzip on;
+      server_tokens off;
+      
+      server {
+        listen 80;
+        server_name _default;
+        root /usr/share/nginx/html;
+        client_max_body_size 500m;
+        gzip_types text/plain application/xml;
+        index index.php;
+        
+        location ~ \.ht {
+          deny all;
+        }
+        
+        location / {
+          try_files $uri $uri/ @rewrite;
+        }
+        
+        location @rewrite {
+          rewrite ^/(.*)$ /index.php;
+        }
+        
+        location ^~ /maintenance/ {
+          return 403;
+        }
+        location /healthz {
+          return 200;
+        }
+        
+        location ~ \.php$ {
+          fastcgi_param QUERY_STRING $query_string;
+          fastcgi_param REQUEST_METHOD $request_method;
+          fastcgi_param CONTENT_TYPE $content_type;
+          fastcgi_param CONTENT_LENGTH $content_length;
+          fastcgi_param SCRIPT_NAME $fastcgi_script_name;
+          fastcgi_param REQUEST_URI $request_uri;
+          fastcgi_param DOCUMENT_URI $document_uri;
+          fastcgi_param DOCUMENT_ROOT $document_root;
+          fastcgi_param SERVER_PROTOCOL $server_protocol;
+          fastcgi_param REQUEST_SCHEME $scheme;
+          fastcgi_param HTTPS $https if_not_empty;
+          fastcgi_param GATEWAY_INTERFACE CGI/1.1;
+          fastcgi_param SERVER_SOFTWARE nginx/$nginx_version;
+          fastcgi_param REMOTE_ADDR $remote_addr;
+          fastcgi_param REMOTE_PORT $remote_port;
+          fastcgi_param SERVER_ADDR $server_addr;
+          fastcgi_param SERVER_PORT $server_port;
+          fastcgi_param SERVER_NAME $server_name;
+          # PHP only, required if PHP was built with --enable-force-cgi-redirect
+          fastcgi_param REDIRECT_STATUS 200;
+          include /etc/nginx/fastcgi_params;
+          fastcgi_index index.php;
+          fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+          try_files $uri @rewrite;
+          fastcgi_pass pathfinderwiki-php-fpm-service:9090;
+        }
+      }
+    }

--- a/apps/base/pathfinderwiki/nginx/03-nginx-deployment.yaml
+++ b/apps/base/pathfinderwiki/nginx/03-nginx-deployment.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pathfinderwiki-nginx
+  namespace: pathfinderwiki
+spec:
+  selector:
+    matchLabels:
+      app: pathfinderwiki-nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: pathfinderwiki-nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.17-alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: wiki-content
+              mountPath: /usr/share/nginx/html
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: pathfinderwiki-nginx-config
+        - name: wiki-content
+          persistentVolumeClaim:
+            claimName: pathfinderwiki-content-pvc

--- a/apps/base/pathfinderwiki/nginx/04-nginx-service.yaml
+++ b/apps/base/pathfinderwiki/nginx/04-nginx-service.yaml
@@ -1,0 +1,13 @@
+---
+# Service to expose Nginx internally
+apiVersion: v1
+kind: Service
+metadata:
+  name: pathfinderwiki-nginx-service
+  namespace: pathfinderwiki
+spec:
+  selector:
+    app: pathfinderwiki-nginx
+  ports:
+    - port: 80
+      targetPort: 80

--- a/apps/base/pathfinderwiki/php-fpm/03-phpfpm-deployment.yaml
+++ b/apps/base/pathfinderwiki/php-fpm/03-phpfpm-deployment.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pathfinderwiki-php-fpm
+  namespace: pathfinderwiki
+spec:
+  selector:
+    matchLabels:
+      app: pathfinderwiki-php-fpm
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: pathfinderwiki-php-fpm
+    spec:
+      containers:
+        - name: php-fpm
+          image: joseluisq/php-fpm:8.3
+          env:
+            - name: ENV_SUBSTITUTION_ENABLE
+              value: "true"
+            - name: PHP_MEMORY_LIMIT
+              value: "512M"
+            - name: PHP_FPM_LISTEN
+              value: "9090"
+            - name: PHP_SESSION_GC_MAXLIFETIME
+              value: "7200"
+            # Database connection details using the secret
+            - name: DB_HOST
+              value: "pathfinderwiki-mariadb-service"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: password
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: mariadb-secrets
+                  key: database
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: pathfinderwiki-content
+              mountPath: /usr/share/nginx/html 
+      volumes:
+        - name: pathfinderwiki-content
+          persistentVolumeClaim:
+            claimName: pathfinderwiki-content-pvc

--- a/apps/base/pathfinderwiki/php-fpm/04-phpfpm-service.yaml
+++ b/apps/base/pathfinderwiki/php-fpm/04-phpfpm-service.yaml
@@ -1,0 +1,13 @@
+---
+# Service to expose PHP-FPM
+apiVersion: v1
+kind: Service
+metadata:
+  name: pathfinderwiki-php-fpm-service
+  namespace: pathfinderwiki
+spec:
+  selector:
+    app: pathfinderwiki-php-fpm
+  ports:
+    - port: 9090
+      targetPort: 9090

--- a/apps/base/vaultwarden/00-namespace.yaml
+++ b/apps/base/vaultwarden/00-namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vaultwarden
+

--- a/apps/base/vaultwarden/01-persistent-volumes.yaml
+++ b/apps/base/vaultwarden/01-persistent-volumes.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: vaultwarden-data-pv
+  namespace: vaultwarden
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: vaultwarden-data-storage
+  nfs:
+    path: /data/nfs/vaultwarden-data
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: vaultwarden-backup-pv
+  namespace: vaultwarden
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: vaultwarden-backup-storage
+  nfs:
+    path: /data/nfs/vaultwarden-backup
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+

--- a/apps/base/vaultwarden/02-persistent-volume-claims.yaml
+++ b/apps/base/vaultwarden/02-persistent-volume-claims.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vaultwarden-data-pvc
+  namespace: vaultwarden
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: vaultwarden-data-storage
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vaultwarden-backup-pvc
+  namespace: vaultwarden
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: vaultwarden-backup-storage

--- a/apps/base/vaultwarden/03-deployment.yaml
+++ b/apps/base/vaultwarden/03-deployment.yaml
@@ -1,0 +1,35 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vaultwarden
+  namespace: vaultwarden
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vaultwarden
+  template:
+    metadata:
+      labels:
+        app: vaultwarden
+    spec:
+      containers:
+        - name: vaultwarden
+          image: vaultwarden/server:1.32.7-alpine
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: vaultwarden-data-storage
+              mountPath: /data
+            - name: vaultwarden-backup-storage
+              mountPath: /backup
+      volumes:
+        - name: vaultwarden-data-storage
+          persistentVolumeClaim:
+            claimName: vaultwarden-data-pvc
+        - name: vaultwarden-backup-storage
+          persistentVolumeClaim:
+            claimName: vaultwarden-backup-pvc
+

--- a/apps/base/vaultwarden/04-service.yaml
+++ b/apps/base/vaultwarden/04-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vaultwarden-service
+  namespace: vaultwarden
+spec:
+  selector:
+    app: vaultwarden
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/apps/base/vaultwarden/05-ingress-route.yaml
+++ b/apps/base/vaultwarden/05-ingress-route.yaml
@@ -1,0 +1,23 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: vaultwarden-ingress
+  namespace: vaultwarden
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`vaultwarden.tommahs.nl`)
+      priority: 10
+      services:
+        - kind: Service
+          name: vaultwarden-service
+          namespace: vaultwarden
+          passHostHeader: true
+          port: 80
+          responseForwarding:
+            flushInterval: 1ms
+  tls:
+    secretName: vaultwarden-tls

--- a/apps/base/vaultwarden/06-backup-cronjob.yaml
+++ b/apps/base/vaultwarden/06-backup-cronjob.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vaultwarden-backup
+  namespace: vaultwarden
+spec:
+  schedule: "0 * * * *"  # Hourly backup
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          volumes:
+            - name: vaultwarden-storage
+              persistentVolumeClaim:
+                claimName: vaultwarden-data-pvc
+            - name: backup-storage
+              persistentVolumeClaim:
+                claimName: vaultwarden-backup-pvc
+          containers:
+            - name: backup
+              image: alpine:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  echo "Starting Vaultwarden backup..."
+                  mkdir -p /backup/
+                  timestamp=$(date +%Y%m%d-%H%M%S)
+                  tar -czvf /backup/vaultwarden-backup-$timestamp.tar.gz /data
+                  echo "Backup completed: /backup/vaultwarden-backup-$timestamp.tar.gz"
+              volumeMounts:
+                - name: vaultwarden-storage
+                  mountPath: /data
+                - name: backup-storage
+                  mountPath: /backup
+

--- a/apps/base/vaultwarden/10-certificate.yaml
+++ b/apps/base/vaultwarden/10-certificate.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vaultwarden-tls
+  namespace: vaultwarden
+spec:
+  secretName: vaultwarden-tls
+  dnsNames:
+    - vaultwarden.tommahs.nl
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/apps/base/vaultwarden/10-ingress-middleware.yaml
+++ b/apps/base/vaultwarden/10-ingress-middleware.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-to-https
+  namespace: vaultwarden
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true

--- a/apps/base/vaultwarden/kustomization.yaml
+++ b/apps/base/vaultwarden/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: vaultwarden
+resources:
+  - 00-namespace.yaml
+  - 01-persistent-volumes.yaml
+  - 02-persistent-volume-claims.yaml
+  - 03-deployment.yaml
+  - 04-service.yaml
+  - 05-ingress-route.yaml
+  - 06-backup-cronjob.yaml
+  - 10-certificate.yaml
+  - 10-ingress-middleware.yaml

--- a/infrastructure/controllers/base/00-cilium/hubble-ingressroute.yaml
+++ b/infrastructure/controllers/base/00-cilium/hubble-ingressroute.yaml
@@ -1,0 +1,18 @@
+---
+# Traefik IngressRoute configuration for Hubble UI
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: traefik-hubble
+  namespace: traefik
+spec:
+  entryPoints:
+    - web
+    - websecure
+  routes:
+    - match: Host(`hubble-ui.k8s.tommahs.nl`)
+      kind: Rule
+      services:
+        - name: hubble-ui
+          port: 80
+          namespace: kube-system

--- a/infrastructure/controllers/base/00-cilium/values.yaml
+++ b/infrastructure/controllers/base/00-cilium/values.yaml
@@ -1,0 +1,35 @@
+--- 
+# values.yaml for Cilium
+
+# Enable kube-proxy replacement
+kubeProxyReplacement: true
+# Kubernetes Service Host and Port
+k8sServiceHost: k8s.tommahs.nl
+k8sServicePort: 6443
+
+# IPAM Mode
+ipam:
+  mode: kubernetes
+
+# Enable Envoy integration (if applicable)
+envoy:
+  enabled: true
+
+# CNI chaining mode - empty means no chaining (assuming it's left empty as in your command)
+cni:
+  chainingMode: ""
+
+# Enable Hubble and its components
+hubble:
+  enabled: true
+  relay:
+    enabled: true
+    api:
+      addr: "0.0.0.0:4244"
+  ui:
+    enabled: true
+    port: 8081
+    auth:
+      anonymous:
+        enabled: true
+

--- a/infrastructure/controllers/base/01-longhorn/01-cluster-role-binding.yaml
+++ b/infrastructure/controllers/base/01-longhorn/01-cluster-role-binding.yaml
@@ -1,0 +1,36 @@
+---
+# Source: longhorn/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-bind
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-role
+subjects:
+- kind: ServiceAccount
+  name: longhorn-service-account
+  namespace: longhorn-system
+---
+# Source: longhorn/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-support-bundle
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: longhorn-support-bundle
+  namespace: longhorn-system

--- a/infrastructure/controllers/base/01-longhorn/01-cluster-role.yaml
+++ b/infrastructure/controllers/base/01-longhorn/01-cluster-role.yaml
@@ -1,0 +1,66 @@
+---
+# Source: longhorn/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-role
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups: [""]
+  resources: ["pods", "events", "persistentvolumes", "persistentvolumeclaims","persistentvolumeclaims/status", "nodes", "proxy/nodes", "pods/log", "secrets", "services", "endpoints", "configmaps", "serviceaccounts"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets", "statefulsets", "deployments"]
+  verbs: ["*"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["*"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets", "podsecuritypolicies"]
+  verbs: ["*"]
+- apiGroups: ["scheduling.k8s.io"]
+  resources: ["priorityclasses"]
+  verbs: ["watch", "list"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses", "volumeattachments", "volumeattachments/status", "csinodes", "csidrivers"]
+  verbs: ["*"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses", "volumesnapshots", "volumesnapshotcontents", "volumesnapshotcontents/status"]
+  verbs: ["*"]
+- apiGroups: ["longhorn.io"]
+  resources: ["volumes", "volumes/status", "engines", "engines/status", "replicas", "replicas/status", "settings", "settings/status",
+              "engineimages", "engineimages/status", "nodes", "nodes/status", "instancemanagers", "instancemanagers/status",
+              "sharemanagers", "sharemanagers/status", "backingimages", "backingimages/status",
+              "backingimagemanagers", "backingimagemanagers/status", "backingimagedatasources", "backingimagedatasources/status",
+              "backuptargets", "backuptargets/status", "backupvolumes", "backupvolumes/status", "backups", "backups/status",
+              "recurringjobs", "recurringjobs/status", "orphans", "orphans/status", "snapshots", "snapshots/status",
+              "supportbundles", "supportbundles/status", "systembackups", "systembackups/status", "systemrestores", "systemrestores/status",
+              "volumeattachments", "volumeattachments/status", "backupbackingimages", "backupbackingimages/status"]
+  verbs: ["*"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["*"]
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+- apiGroups: ["apiregistration.k8s.io"]
+  resources: ["apiservices"]
+  verbs: ["list", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "create", "patch", "delete"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings", "clusterrolebindings", "clusterroles"]
+  verbs: ["*"]

--- a/infrastructure/controllers/base/01-longhorn/01-namespace.yaml
+++ b/infrastructure/controllers/base/01-longhorn/01-namespace.yaml
@@ -1,0 +1,6 @@
+---
+# Builtin: "helm template" does not respect --create-namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-system

--- a/infrastructure/controllers/base/01-longhorn/02-config-map.yaml
+++ b/infrastructure/controllers/base/01-longhorn/02-config-map.yaml
@@ -1,0 +1,60 @@
+---
+# Source: longhorn/templates/default-resource.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-resource
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+data:
+  default-resource.yaml: |-
+---
+# Source: longhorn/templates/default-setting.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-setting
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+data:
+  default-setting.yaml: |-
+    priority-class: longhorn-critical
+    disable-revision-counter: true
+---
+# Source: longhorn/templates/storageclass.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-storageclass
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+data:
+  storageclass.yaml: |
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+      name: longhorn
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: driver.longhorn.io
+    allowVolumeExpansion: true
+    reclaimPolicy: "Delete"
+    volumeBindingMode: Immediate
+    parameters:
+      numberOfReplicas: "3"
+      staleReplicaTimeout: "30"
+      fromBackup: ""
+      fsType: "ext4"
+      dataLocality: "disabled"
+      unmapMarkSnapChainRemoved: "ignored"
+      disableRevisionCounter: "true"
+      dataEngine: "v1"

--- a/infrastructure/controllers/base/01-longhorn/02-custom-resource-definition.yaml
+++ b/infrastructure/controllers/base/01-longhorn/02-custom-resource-definition.yaml
@@ -1,0 +1,4606 @@
+---
+# Source: longhorn/templates/crds.yaml
+# Generated crds.yaml from github.com/longhorn/longhorn-manager/k8s/pkg/apis and the crds.yaml will be copied to longhorn/longhorn chart/templates and cannot be directly used by kubectl apply.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: backingimagedatasources.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: BackingImageDataSource
+    listKind: BackingImageDataSourceList
+    plural: backingimagedatasources
+    shortNames:
+    - lhbids
+    singular: backingimagedatasource
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The current state of the pod used to provision the backing image
+        file from source
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The data source type
+      jsonPath: .spec.sourceType
+      name: SourceType
+      type: string
+    - description: The node the backing image file will be prepared on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - description: The disk the backing image file will be prepared on
+      jsonPath: .spec.diskUUID
+      name: DiskUUID
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BackingImageDataSource is where Longhorn stores backing image
+          data source object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The system generated UUID of the provisioned backing image file
+      jsonPath: .spec.uuid
+      name: UUID
+      type: string
+    - description: The current state of the pod used to provision the backing image
+        file from source
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The data source type
+      jsonPath: .spec.sourceType
+      name: SourceType
+      type: string
+    - description: The backing image file size
+      jsonPath: .status.size
+      name: Size
+      type: string
+    - description: The node the backing image file will be prepared on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - description: The disk the backing image file will be prepared on
+      jsonPath: .spec.diskUUID
+      name: DiskUUID
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: BackingImageDataSource is where Longhorn stores backing image
+          data source object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackingImageDataSourceSpec defines the desired state of the
+              Longhorn backing image data source
+            properties:
+              checksum:
+                type: string
+              diskPath:
+                type: string
+              diskUUID:
+                type: string
+              fileTransferred:
+                type: boolean
+              nodeID:
+                type: string
+              parameters:
+                additionalProperties:
+                  type: string
+                type: object
+              sourceType:
+                enum:
+                - download
+                - upload
+                - export-from-volume
+                - restore
+                - clone
+                type: string
+              uuid:
+                type: string
+            type: object
+          status:
+            description: BackingImageDataSourceStatus defines the observed state of
+              the Longhorn backing image data source
+            properties:
+              checksum:
+                type: string
+              currentState:
+                type: string
+              ip:
+                type: string
+              message:
+                type: string
+              ownerID:
+                type: string
+              progress:
+                type: integer
+              runningParameters:
+                additionalProperties:
+                  type: string
+                nullable: true
+                type: object
+              size:
+                format: int64
+                type: integer
+              storageIP:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: backingimagemanagers.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: BackingImageManager
+    listKind: BackingImageManagerList
+    plural: backingimagemanagers
+    shortNames:
+    - lhbim
+    singular: backingimagemanager
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The current state of the manager
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The image the manager pod will use
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - description: The node the manager is on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - description: The disk the manager is responsible for
+      jsonPath: .spec.diskUUID
+      name: DiskUUID
+      type: string
+    - description: The disk path the manager is using
+      jsonPath: .spec.diskPath
+      name: DiskPath
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BackingImageManager is where Longhorn stores backing image manager
+          object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The current state of the manager
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The image the manager pod will use
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - description: The node the manager is on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - description: The disk the manager is responsible for
+      jsonPath: .spec.diskUUID
+      name: DiskUUID
+      type: string
+    - description: The disk path the manager is using
+      jsonPath: .spec.diskPath
+      name: DiskPath
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: BackingImageManager is where Longhorn stores backing image manager
+          object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackingImageManagerSpec defines the desired state of the
+              Longhorn backing image manager
+            properties:
+              backingImages:
+                additionalProperties:
+                  type: string
+                type: object
+              diskPath:
+                type: string
+              diskUUID:
+                type: string
+              image:
+                type: string
+              nodeID:
+                type: string
+            type: object
+          status:
+            description: BackingImageManagerStatus defines the observed state of the
+              Longhorn backing image manager
+            properties:
+              apiMinVersion:
+                type: integer
+              apiVersion:
+                type: integer
+              backingImageFileMap:
+                additionalProperties:
+                  properties:
+                    currentChecksum:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    progress:
+                      type: integer
+                    realSize:
+                      format: int64
+                      type: integer
+                    senderManagerAddress:
+                      type: string
+                    sendingReference:
+                      type: integer
+                    size:
+                      format: int64
+                      type: integer
+                    state:
+                      type: string
+                    uuid:
+                      type: string
+                    virtualSize:
+                      format: int64
+                      type: integer
+                  type: object
+                nullable: true
+                type: object
+              currentState:
+                type: string
+              ip:
+                type: string
+              ownerID:
+                type: string
+              storageIP:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: backingimages.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
+  group: longhorn.io
+  names:
+    kind: BackingImage
+    listKind: BackingImageList
+    plural: backingimages
+    shortNames:
+    - lhbi
+    singular: backingimage
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The backing image name
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BackingImage is where Longhorn stores backing image object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The system generated UUID
+      jsonPath: .status.uuid
+      name: UUID
+      type: string
+    - description: The source of the backing image file data
+      jsonPath: .spec.sourceType
+      name: SourceType
+      type: string
+    - description: The backing image file size in each disk
+      jsonPath: .status.size
+      name: Size
+      type: string
+    - description: The virtual size of the image (may be larger than file size)
+      jsonPath: .status.virtualSize
+      name: VirtualSize
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: BackingImage is where Longhorn stores backing image object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackingImageSpec defines the desired state of the Longhorn
+              backing image
+            properties:
+              checksum:
+                type: string
+              dataEngine:
+                default: v1
+                enum:
+                - v1
+                - v2
+                type: string
+              diskFileSpecMap:
+                additionalProperties:
+                  properties:
+                    dataEngine:
+                      enum:
+                      - v1
+                      - v2
+                      type: string
+                    evictionRequested:
+                      type: boolean
+                  type: object
+                type: object
+              diskSelector:
+                items:
+                  type: string
+                type: array
+              disks:
+                additionalProperties:
+                  type: string
+                description: Deprecated. We are now using DiskFileSpecMap to assign
+                  different spec to the file on different disks.
+                type: object
+              minNumberOfCopies:
+                type: integer
+              nodeSelector:
+                items:
+                  type: string
+                type: array
+              secret:
+                type: string
+              secretNamespace:
+                type: string
+              sourceParameters:
+                additionalProperties:
+                  type: string
+                type: object
+              sourceType:
+                enum:
+                - download
+                - upload
+                - export-from-volume
+                - restore
+                - clone
+                type: string
+            type: object
+          status:
+            description: BackingImageStatus defines the observed state of the Longhorn
+              backing image status
+            properties:
+              checksum:
+                type: string
+              diskFileStatusMap:
+                additionalProperties:
+                  properties:
+                    dataEngine:
+                      enum:
+                      - v1
+                      - v2
+                      type: string
+                    lastStateTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                    progress:
+                      type: integer
+                    state:
+                      type: string
+                  type: object
+                nullable: true
+                type: object
+              diskLastRefAtMap:
+                additionalProperties:
+                  type: string
+                nullable: true
+                type: object
+              ownerID:
+                type: string
+              realSize:
+                description: Real size of image in bytes, which may be smaller than
+                  the size when the file is a sparse file. Will be zero until known
+                  (e.g. while a backing image is uploading)
+                format: int64
+                type: integer
+              size:
+                format: int64
+                type: integer
+              uuid:
+                type: string
+              v2FirstCopyDisk:
+                type: string
+              v2FirstCopyStatus:
+                description: It is pending -> in-progress -> ready/failed
+                type: string
+              virtualSize:
+                description: Virtual size of image in bytes, which may be larger than
+                  physical size. Will be zero until known (e.g. while a backing image
+                  is uploading)
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: backupbackingimages.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: BackupBackingImage
+    listKind: BackupBackingImageList
+    plural: backupbackingimages
+    shortNames:
+    - lhbbi
+    singular: backupbackingimage
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The backing image name
+      jsonPath: .status.backingImage
+      name: BackingImage
+      type: string
+    - description: The backing image size
+      jsonPath: .status.size
+      name: Size
+      type: string
+    - description: The backing image backup upload finished time
+      jsonPath: .status.backupCreatedAt
+      name: BackupCreatedAt
+      type: string
+    - description: The backing image backup state
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The last synced time
+      jsonPath: .status.lastSyncedAt
+      name: LastSyncedAt
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: BackupBackingImage is where Longhorn stores backing image backup
+          object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupBackingImageSpec defines the desired state of the Longhorn
+              backing image backup
+            properties:
+              backingImage:
+                description: The backing image name.
+                type: string
+              backupTargetName:
+                description: The backup target name.
+                nullable: true
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: The labels of backing image backup.
+                type: object
+              syncRequestedAt:
+                description: The time to request run sync the remote backing image
+                  backup.
+                format: date-time
+                nullable: true
+                type: string
+              userCreated:
+                description: Is this CR created by user through API or UI.
+                type: boolean
+            required:
+            - backingImage
+            - userCreated
+            type: object
+          status:
+            description: BackupBackingImageStatus defines the observed state of the
+              Longhorn backing image backup
+            properties:
+              backingImage:
+                description: The backing image name.
+                type: string
+              backupCreatedAt:
+                description: The backing image backup upload finished time.
+                type: string
+              checksum:
+                description: The checksum of the backing image.
+                type: string
+              compressionMethod:
+                description: Compression method
+                type: string
+              error:
+                description: The error message when taking the backing image backup.
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: The labels of backing image backup.
+                nullable: true
+                type: object
+              lastSyncedAt:
+                description: The last time that the backing image backup was synced
+                  with the remote backup target.
+                format: date-time
+                nullable: true
+                type: string
+              managerAddress:
+                description: The address of the backing image manager that runs backing
+                  image backup.
+                type: string
+              messages:
+                additionalProperties:
+                  type: string
+                description: The error messages when listing or inspecting backing
+                  image backup.
+                nullable: true
+                type: object
+              ownerID:
+                description: The node ID on which the controller is responsible to
+                  reconcile this CR.
+                type: string
+              progress:
+                description: The backing image backup progress.
+                type: integer
+              secret:
+                description: Record the secret if this backup backing image is encrypted
+                type: string
+              secretNamespace:
+                description: Record the secret namespace if this backup backing image
+                  is encrypted
+                type: string
+              size:
+                description: The backing image size.
+                format: int64
+                type: integer
+              state:
+                description: |-
+                  The backing image backup creation state.
+                  Can be "", "InProgress", "Completed", "Error", "Unknown".
+                type: string
+              url:
+                description: The backing image backup URL.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: backups.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    shortNames:
+    - lhb
+    singular: backup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The snapshot name
+      jsonPath: .status.snapshotName
+      name: SnapshotName
+      type: string
+    - description: The snapshot size
+      jsonPath: .status.size
+      name: SnapshotSize
+      type: string
+    - description: The snapshot creation time
+      jsonPath: .status.snapshotCreatedAt
+      name: SnapshotCreatedAt
+      type: string
+    - description: The backup state
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The backup last synced time
+      jsonPath: .status.lastSyncedAt
+      name: LastSyncedAt
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Backup is where Longhorn stores backup object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The snapshot name
+      jsonPath: .status.snapshotName
+      name: SnapshotName
+      type: string
+    - description: The snapshot size
+      jsonPath: .status.size
+      name: SnapshotSize
+      type: string
+    - description: The snapshot creation time
+      jsonPath: .status.snapshotCreatedAt
+      name: SnapshotCreatedAt
+      type: string
+    - description: The backup target name
+      jsonPath: .status.backupTargetName
+      name: BackupTarget
+      type: string
+    - description: The backup state
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The backup last synced time
+      jsonPath: .status.lastSyncedAt
+      name: LastSyncedAt
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Backup is where Longhorn stores backup object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupSpec defines the desired state of the Longhorn backup
+            properties:
+              backupMode:
+                description: |-
+                  The backup mode of this backup.
+                  Can be "full" or "incremental"
+                enum:
+                - full
+                - incremental
+                - ""
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: The labels of snapshot backup.
+                type: object
+              snapshotName:
+                description: The snapshot name.
+                type: string
+              syncRequestedAt:
+                description: The time to request run sync the remote backup.
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+          status:
+            description: BackupStatus defines the observed state of the Longhorn backup
+            properties:
+              backupCreatedAt:
+                description: The snapshot backup upload finished time.
+                type: string
+              backupTargetName:
+                description: The backup target name.
+                type: string
+              compressionMethod:
+                description: Compression method
+                type: string
+              error:
+                description: The error message when taking the snapshot backup.
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: The labels of snapshot backup.
+                nullable: true
+                type: object
+              lastSyncedAt:
+                description: The last time that the backup was synced with the remote
+                  backup target.
+                format: date-time
+                nullable: true
+                type: string
+              messages:
+                additionalProperties:
+                  type: string
+                description: The error messages when calling longhorn engine on listing
+                  or inspecting backups.
+                nullable: true
+                type: object
+              newlyUploadDataSize:
+                description: Size in bytes of newly uploaded data
+                type: string
+              ownerID:
+                description: The node ID on which the controller is responsible to
+                  reconcile this backup CR.
+                type: string
+              progress:
+                description: The snapshot backup progress.
+                type: integer
+              reUploadedDataSize:
+                description: Size in bytes of reuploaded data
+                type: string
+              replicaAddress:
+                description: The address of the replica that runs snapshot backup.
+                type: string
+              size:
+                description: The snapshot size.
+                type: string
+              snapshotCreatedAt:
+                description: The snapshot creation time.
+                type: string
+              snapshotName:
+                description: The snapshot name.
+                type: string
+              state:
+                description: |-
+                  The backup creation state.
+                  Can be "", "InProgress", "Completed", "Error", "Unknown".
+                type: string
+              url:
+                description: The snapshot backup URL.
+                type: string
+              volumeBackingImageName:
+                description: The volume's backing image name.
+                type: string
+              volumeCreated:
+                description: The volume creation time.
+                type: string
+              volumeName:
+                description: The volume name.
+                type: string
+              volumeSize:
+                description: The volume size.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: backuptargets.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
+  group: longhorn.io
+  names:
+    kind: BackupTarget
+    listKind: BackupTargetList
+    plural: backuptargets
+    shortNames:
+    - lhbt
+    singular: backuptarget
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The backup target URL
+      jsonPath: .spec.backupTargetURL
+      name: URL
+      type: string
+    - description: The backup target credential secret
+      jsonPath: .spec.credentialSecret
+      name: Credential
+      type: string
+    - description: The backup target poll interval
+      jsonPath: .spec.pollInterval
+      name: LastBackupAt
+      type: string
+    - description: Indicate whether the backup target is available or not
+      jsonPath: .status.available
+      name: Available
+      type: boolean
+    - description: The backup target last synced time
+      jsonPath: .status.lastSyncedAt
+      name: LastSyncedAt
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BackupTarget is where Longhorn stores backup target object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The backup target URL
+      jsonPath: .spec.backupTargetURL
+      name: URL
+      type: string
+    - description: The backup target credential secret
+      jsonPath: .spec.credentialSecret
+      name: Credential
+      type: string
+    - description: The backup target poll interval
+      jsonPath: .spec.pollInterval
+      name: LastBackupAt
+      type: string
+    - description: Indicate whether the backup target is available or not
+      jsonPath: .status.available
+      name: Available
+      type: boolean
+    - description: The backup target last synced time
+      jsonPath: .status.lastSyncedAt
+      name: LastSyncedAt
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: BackupTarget is where Longhorn stores backup target object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupTargetSpec defines the desired state of the Longhorn
+              backup target
+            properties:
+              backupTargetURL:
+                description: The backup target URL.
+                type: string
+              credentialSecret:
+                description: The backup target credential secret.
+                type: string
+              pollInterval:
+                description: The interval that the cluster needs to run sync with
+                  the backup target.
+                type: string
+              syncRequestedAt:
+                description: The time to request run sync the remote backup target.
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+          status:
+            description: BackupTargetStatus defines the observed state of the Longhorn
+              backup target
+            properties:
+              available:
+                description: Available indicates if the remote backup target is available
+                  or not.
+                type: boolean
+              conditions:
+                description: Records the reason on why the backup target is unavailable.
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              lastSyncedAt:
+                description: The last time that the controller synced with the remote
+                  backup target.
+                format: date-time
+                nullable: true
+                type: string
+              ownerID:
+                description: The node ID on which the controller is responsible to
+                  reconcile this backup target CR.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: backupvolumes.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: BackupVolume
+    listKind: BackupVolumeList
+    plural: backupvolumes
+    shortNames:
+    - lhbv
+    singular: backupvolume
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The backup volume creation time
+      jsonPath: .status.createdAt
+      name: CreatedAt
+      type: string
+    - description: The backup volume last backup name
+      jsonPath: .status.lastBackupName
+      name: LastBackupName
+      type: string
+    - description: The backup volume last backup time
+      jsonPath: .status.lastBackupAt
+      name: LastBackupAt
+      type: string
+    - description: The backup volume last synced time
+      jsonPath: .status.lastSyncedAt
+      name: LastSyncedAt
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: BackupVolume is where Longhorn stores backup volume object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The backup target name
+      jsonPath: .spec.backupTargetName
+      name: BackupTarget
+      type: string
+    - description: The backup volume creation time
+      jsonPath: .status.createdAt
+      name: CreatedAt
+      type: string
+    - description: The backup volume last backup name
+      jsonPath: .status.lastBackupName
+      name: LastBackupName
+      type: string
+    - description: The backup volume last backup time
+      jsonPath: .status.lastBackupAt
+      name: LastBackupAt
+      type: string
+    - description: The backup volume last synced time
+      jsonPath: .status.lastSyncedAt
+      name: LastSyncedAt
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: BackupVolume is where Longhorn stores backup volume object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupVolumeSpec defines the desired state of the Longhorn
+              backup volume
+            properties:
+              backupTargetName:
+                description: The backup target name that the backup volume was synced.
+                nullable: true
+                type: string
+              syncRequestedAt:
+                description: The time to request run sync the remote backup volume.
+                format: date-time
+                nullable: true
+                type: string
+              volumeName:
+                description: The volume name that the backup volume was used to backup.
+                type: string
+            type: object
+          status:
+            description: BackupVolumeStatus defines the observed state of the Longhorn
+              backup volume
+            properties:
+              backingImageChecksum:
+                description: the backing image checksum.
+                type: string
+              backingImageName:
+                description: The backing image name.
+                type: string
+              createdAt:
+                description: The backup volume creation time.
+                type: string
+              dataStored:
+                description: The backup volume block count.
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: The backup volume labels.
+                nullable: true
+                type: object
+              lastBackupAt:
+                description: The latest volume backup time.
+                type: string
+              lastBackupName:
+                description: The latest volume backup name.
+                type: string
+              lastModificationTime:
+                description: The backup volume config last modification time.
+                format: date-time
+                nullable: true
+                type: string
+              lastSyncedAt:
+                description: The last time that the backup volume was synced into
+                  the cluster.
+                format: date-time
+                nullable: true
+                type: string
+              messages:
+                additionalProperties:
+                  type: string
+                description: The error messages when call longhorn engine on list
+                  or inspect backup volumes.
+                nullable: true
+                type: object
+              ownerID:
+                description: The node ID on which the controller is responsible to
+                  reconcile this backup volume CR.
+                type: string
+              size:
+                description: The backup volume size.
+                type: string
+              storageClassName:
+                description: the storage class name of pv/pvc binding with the volume.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: engineimages.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
+  group: longhorn.io
+  names:
+    kind: EngineImage
+    listKind: EngineImageList
+    plural: engineimages
+    shortNames:
+    - lhei
+    singular: engineimage
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: State of the engine image
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The Longhorn engine image
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - description: Number of resources using the engine image
+      jsonPath: .status.refCount
+      name: RefCount
+      type: integer
+    - description: The build date of the engine image
+      jsonPath: .status.buildDate
+      name: BuildDate
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: EngineImage is where Longhorn stores engine image object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Compatibility of the engine image
+      jsonPath: .status.incompatible
+      name: Incompatible
+      type: boolean
+    - description: State of the engine image
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The Longhorn engine image
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - description: Number of resources using the engine image
+      jsonPath: .status.refCount
+      name: RefCount
+      type: integer
+    - description: The build date of the engine image
+      jsonPath: .status.buildDate
+      name: BuildDate
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: EngineImage is where Longhorn stores engine image object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EngineImageSpec defines the desired state of the Longhorn
+              engine image
+            properties:
+              image:
+                minLength: 1
+                type: string
+            required:
+            - image
+            type: object
+          status:
+            description: EngineImageStatus defines the observed state of the Longhorn
+              engine image
+            properties:
+              buildDate:
+                type: string
+              cliAPIMinVersion:
+                type: integer
+              cliAPIVersion:
+                type: integer
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              controllerAPIMinVersion:
+                type: integer
+              controllerAPIVersion:
+                type: integer
+              dataFormatMinVersion:
+                type: integer
+              dataFormatVersion:
+                type: integer
+              gitCommit:
+                type: string
+              incompatible:
+                type: boolean
+              noRefSince:
+                type: string
+              nodeDeploymentMap:
+                additionalProperties:
+                  type: boolean
+                nullable: true
+                type: object
+              ownerID:
+                type: string
+              refCount:
+                type: integer
+              state:
+                type: string
+              version:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: engines.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Engine
+    listKind: EngineList
+    plural: engines
+    shortNames:
+    - lhe
+    singular: engine
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The current state of the engine
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The node that the engine is on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - description: The instance manager of the engine
+      jsonPath: .status.instanceManagerName
+      name: InstanceManager
+      type: string
+    - description: The current image of the engine
+      jsonPath: .status.currentImage
+      name: Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Engine is where Longhorn stores engine object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The data engine of the engine
+      jsonPath: .spec.dataEngine
+      name: Data Engine
+      type: string
+    - description: The current state of the engine
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The node that the engine is on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - description: The instance manager of the engine
+      jsonPath: .status.instanceManagerName
+      name: InstanceManager
+      type: string
+    - description: The current image of the engine
+      jsonPath: .status.currentImage
+      name: Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Engine is where Longhorn stores engine object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EngineSpec defines the desired state of the Longhorn engine
+            properties:
+              active:
+                type: boolean
+              backendStoreDriver:
+                description: Deprecated:Replaced by field `dataEngine`.
+                type: string
+              backupVolume:
+                type: string
+              dataEngine:
+                enum:
+                - v1
+                - v2
+                type: string
+              desireState:
+                type: string
+              disableFrontend:
+                type: boolean
+              engineImage:
+                description: 'Deprecated: Replaced by field `image`.'
+                type: string
+              frontend:
+                enum:
+                - blockdev
+                - iscsi
+                - nvmf
+                - ""
+                type: string
+              image:
+                type: string
+              logRequested:
+                type: boolean
+              nodeID:
+                type: string
+              replicaAddressMap:
+                additionalProperties:
+                  type: string
+                type: object
+              requestedBackupRestore:
+                type: string
+              requestedDataSource:
+                type: string
+              revisionCounterDisabled:
+                type: boolean
+              salvageRequested:
+                type: boolean
+              snapshotMaxCount:
+                type: integer
+              snapshotMaxSize:
+                format: int64
+                type: string
+              unmapMarkSnapChainRemovedEnabled:
+                type: boolean
+              upgradedReplicaAddressMap:
+                additionalProperties:
+                  type: string
+                type: object
+              volumeName:
+                type: string
+              volumeSize:
+                format: int64
+                type: string
+            type: object
+          status:
+            description: EngineStatus defines the observed state of the Longhorn engine
+            properties:
+              backupStatus:
+                additionalProperties:
+                  properties:
+                    backupURL:
+                      type: string
+                    error:
+                      type: string
+                    progress:
+                      type: integer
+                    replicaAddress:
+                      type: string
+                    snapshotName:
+                      type: string
+                    state:
+                      type: string
+                  type: object
+                nullable: true
+                type: object
+              cloneStatus:
+                additionalProperties:
+                  properties:
+                    error:
+                      type: string
+                    fromReplicaAddress:
+                      type: string
+                    isCloning:
+                      type: boolean
+                    progress:
+                      type: integer
+                    snapshotName:
+                      type: string
+                    state:
+                      type: string
+                  type: object
+                nullable: true
+                type: object
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              currentImage:
+                type: string
+              currentReplicaAddressMap:
+                additionalProperties:
+                  type: string
+                nullable: true
+                type: object
+              currentSize:
+                format: int64
+                type: string
+              currentState:
+                type: string
+              endpoint:
+                type: string
+              instanceManagerName:
+                type: string
+              ip:
+                type: string
+              isExpanding:
+                type: boolean
+              lastExpansionError:
+                type: string
+              lastExpansionFailedAt:
+                type: string
+              lastRestoredBackup:
+                type: string
+              logFetched:
+                type: boolean
+              ownerID:
+                type: string
+              port:
+                type: integer
+              purgeStatus:
+                additionalProperties:
+                  properties:
+                    error:
+                      type: string
+                    isPurging:
+                      type: boolean
+                    progress:
+                      type: integer
+                    state:
+                      type: string
+                  type: object
+                nullable: true
+                type: object
+              rebuildStatus:
+                additionalProperties:
+                  properties:
+                    error:
+                      type: string
+                    fromReplicaAddress:
+                      type: string
+                    isRebuilding:
+                      type: boolean
+                    progress:
+                      type: integer
+                    state:
+                      type: string
+                  type: object
+                nullable: true
+                type: object
+              replicaModeMap:
+                additionalProperties:
+                  type: string
+                nullable: true
+                type: object
+              replicaTransitionTimeMap:
+                additionalProperties:
+                  type: string
+                description: |-
+                  ReplicaTransitionTimeMap records the time a replica in ReplicaModeMap transitions from one mode to another (or
+                  from not being in the ReplicaModeMap to being in it). This information is sometimes required by other controllers
+                  (e.g. the volume controller uses it to determine the correct value for replica.Spec.lastHealthyAt).
+                type: object
+              restoreStatus:
+                additionalProperties:
+                  properties:
+                    backupURL:
+                      type: string
+                    currentRestoringBackup:
+                      type: string
+                    error:
+                      type: string
+                    filename:
+                      type: string
+                    isRestoring:
+                      type: boolean
+                    lastRestored:
+                      type: string
+                    progress:
+                      type: integer
+                    state:
+                      type: string
+                  type: object
+                nullable: true
+                type: object
+              salvageExecuted:
+                type: boolean
+              snapshotMaxCount:
+                type: integer
+              snapshotMaxSize:
+                format: int64
+                type: string
+              snapshots:
+                additionalProperties:
+                  properties:
+                    children:
+                      additionalProperties:
+                        type: boolean
+                      nullable: true
+                      type: object
+                    created:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                      type: object
+                    name:
+                      type: string
+                    parent:
+                      type: string
+                    removed:
+                      type: boolean
+                    size:
+                      type: string
+                    usercreated:
+                      type: boolean
+                  type: object
+                nullable: true
+                type: object
+              snapshotsError:
+                type: string
+              started:
+                type: boolean
+              storageIP:
+                type: string
+              unmapMarkSnapChainRemovedEnabled:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: instancemanagers.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: InstanceManager
+    listKind: InstanceManagerList
+    plural: instancemanagers
+    shortNames:
+    - lhim
+    singular: instancemanager
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The state of the instance manager
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The type of the instance manager (engine or replica)
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: The node that the instance manager is running on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: InstanceManager is where Longhorn stores instance manager object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The data engine of the instance manager
+      jsonPath: .spec.dataEngine
+      name: Data Engine
+      type: string
+    - description: The state of the instance manager
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The type of the instance manager (engine or replica)
+      jsonPath: .spec.type
+      name: Type
+      type: string
+    - description: The node that the instance manager is running on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: InstanceManager is where Longhorn stores instance manager object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: InstanceManagerSpec defines the desired state of the Longhorn
+              instance manager
+            properties:
+              dataEngine:
+                type: string
+              dataEngineSpec:
+                properties:
+                  v2:
+                    properties:
+                      cpuMask:
+                        type: string
+                    type: object
+                type: object
+              image:
+                type: string
+              nodeID:
+                type: string
+              type:
+                enum:
+                - aio
+                - engine
+                - replica
+                type: string
+            type: object
+          status:
+            description: InstanceManagerStatus defines the observed state of the Longhorn
+              instance manager
+            properties:
+              apiMinVersion:
+                type: integer
+              apiVersion:
+                type: integer
+              backingImages:
+                additionalProperties:
+                  properties:
+                    currentChecksum:
+                      type: string
+                    diskUUID:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    progress:
+                      type: integer
+                    size:
+                      format: int64
+                      type: integer
+                    state:
+                      type: string
+                    uuid:
+                      type: string
+                  type: object
+                nullable: true
+                type: object
+              currentState:
+                type: string
+              dataEngineStatus:
+                properties:
+                  v2:
+                    properties:
+                      cpuMask:
+                        type: string
+                    type: object
+                type: object
+              instanceEngines:
+                additionalProperties:
+                  properties:
+                    spec:
+                      properties:
+                        backendStoreDriver:
+                          description: Deprecated:Replaced by field `dataEngine`.
+                          type: string
+                        dataEngine:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    status:
+                      properties:
+                        conditions:
+                          additionalProperties:
+                            type: boolean
+                          nullable: true
+                          type: object
+                        endpoint:
+                          type: string
+                        errorMsg:
+                          type: string
+                        listen:
+                          type: string
+                        portEnd:
+                          format: int32
+                          type: integer
+                        portStart:
+                          format: int32
+                          type: integer
+                        resourceVersion:
+                          format: int64
+                          type: integer
+                        state:
+                          type: string
+                        targetPortEnd:
+                          format: int32
+                          type: integer
+                        targetPortStart:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                  type: object
+                nullable: true
+                type: object
+              instanceReplicas:
+                additionalProperties:
+                  properties:
+                    spec:
+                      properties:
+                        backendStoreDriver:
+                          description: Deprecated:Replaced by field `dataEngine`.
+                          type: string
+                        dataEngine:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    status:
+                      properties:
+                        conditions:
+                          additionalProperties:
+                            type: boolean
+                          nullable: true
+                          type: object
+                        endpoint:
+                          type: string
+                        errorMsg:
+                          type: string
+                        listen:
+                          type: string
+                        portEnd:
+                          format: int32
+                          type: integer
+                        portStart:
+                          format: int32
+                          type: integer
+                        resourceVersion:
+                          format: int64
+                          type: integer
+                        state:
+                          type: string
+                        targetPortEnd:
+                          format: int32
+                          type: integer
+                        targetPortStart:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                  type: object
+                nullable: true
+                type: object
+              instances:
+                additionalProperties:
+                  properties:
+                    spec:
+                      properties:
+                        backendStoreDriver:
+                          description: Deprecated:Replaced by field `dataEngine`.
+                          type: string
+                        dataEngine:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    status:
+                      properties:
+                        conditions:
+                          additionalProperties:
+                            type: boolean
+                          nullable: true
+                          type: object
+                        endpoint:
+                          type: string
+                        errorMsg:
+                          type: string
+                        listen:
+                          type: string
+                        portEnd:
+                          format: int32
+                          type: integer
+                        portStart:
+                          format: int32
+                          type: integer
+                        resourceVersion:
+                          format: int64
+                          type: integer
+                        state:
+                          type: string
+                        targetPortEnd:
+                          format: int32
+                          type: integer
+                        targetPortStart:
+                          format: int32
+                          type: integer
+                        type:
+                          type: string
+                      type: object
+                  type: object
+                description: 'Deprecated: Replaced by InstanceEngines and InstanceReplicas'
+                nullable: true
+                type: object
+              ip:
+                type: string
+              ownerID:
+                type: string
+              proxyApiMinVersion:
+                type: integer
+              proxyApiVersion:
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: nodes.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
+  group: longhorn.io
+  names:
+    kind: Node
+    listKind: NodeList
+    plural: nodes
+    shortNames:
+    - lhn
+    singular: node
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Indicate whether the node is ready
+      jsonPath: .status.conditions['Ready']['status']
+      name: Ready
+      type: string
+    - description: Indicate whether the user disabled/enabled replica scheduling for
+        the node
+      jsonPath: .spec.allowScheduling
+      name: AllowScheduling
+      type: boolean
+    - description: Indicate whether Longhorn can schedule replicas on the node
+      jsonPath: .status.conditions['Schedulable']['status']
+      name: Schedulable
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Node is where Longhorn stores Longhorn node object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Indicate whether the node is ready
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: Indicate whether the user disabled/enabled replica scheduling for
+        the node
+      jsonPath: .spec.allowScheduling
+      name: AllowScheduling
+      type: boolean
+    - description: Indicate whether Longhorn can schedule replicas on the node
+      jsonPath: .status.conditions[?(@.type=='Schedulable')].status
+      name: Schedulable
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Node is where Longhorn stores Longhorn node object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeSpec defines the desired state of the Longhorn node
+            properties:
+              allowScheduling:
+                type: boolean
+              disks:
+                additionalProperties:
+                  properties:
+                    allowScheduling:
+                      type: boolean
+                    diskDriver:
+                      enum:
+                      - ""
+                      - auto
+                      - aio
+                      type: string
+                    diskType:
+                      enum:
+                      - filesystem
+                      - block
+                      type: string
+                    evictionRequested:
+                      type: boolean
+                    path:
+                      type: string
+                    storageReserved:
+                      format: int64
+                      type: integer
+                    tags:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: object
+              evictionRequested:
+                type: boolean
+              instanceManagerCPURequest:
+                type: integer
+              name:
+                type: string
+              tags:
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: NodeStatus defines the observed state of the Longhorn node
+            properties:
+              autoEvicting:
+                type: boolean
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              diskStatus:
+                additionalProperties:
+                  properties:
+                    conditions:
+                      items:
+                        properties:
+                          lastProbeTime:
+                            description: Last time we probed the condition.
+                            type: string
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from
+                              one status to another.
+                            type: string
+                          message:
+                            description: Human-readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            description: |-
+                              Status is the status of the condition.
+                              Can be True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the condition.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    diskDriver:
+                      type: string
+                    diskName:
+                      type: string
+                    diskPath:
+                      type: string
+                    diskType:
+                      type: string
+                    diskUUID:
+                      type: string
+                    filesystemType:
+                      type: string
+                    instanceManagerName:
+                      type: string
+                    scheduledBackingImage:
+                      additionalProperties:
+                        format: int64
+                        type: integer
+                      nullable: true
+                      type: object
+                    scheduledReplica:
+                      additionalProperties:
+                        format: int64
+                        type: integer
+                      nullable: true
+                      type: object
+                    storageAvailable:
+                      format: int64
+                      type: integer
+                    storageMaximum:
+                      format: int64
+                      type: integer
+                    storageScheduled:
+                      format: int64
+                      type: integer
+                  type: object
+                nullable: true
+                type: object
+              region:
+                type: string
+              snapshotCheckStatus:
+                properties:
+                  lastPeriodicCheckedAt:
+                    format: date-time
+                    type: string
+                type: object
+              zone:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: orphans.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Orphan
+    listKind: OrphanList
+    plural: orphans
+    shortNames:
+    - lho
+    singular: orphan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The type of the orphan
+      jsonPath: .spec.orphanType
+      name: Type
+      type: string
+    - description: The node that the orphan is on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Orphan is where Longhorn stores orphan object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OrphanSpec defines the desired state of the Longhorn orphaned
+              data
+            properties:
+              nodeID:
+                description: The node ID on which the controller is responsible to
+                  reconcile this orphan CR.
+                type: string
+              orphanType:
+                description: |-
+                  The type of the orphaned data.
+                  Can be "replica".
+                type: string
+              parameters:
+                additionalProperties:
+                  type: string
+                description: The parameters of the orphaned data
+                type: object
+            type: object
+          status:
+            description: OrphanStatus defines the observed state of the Longhorn orphaned
+              data
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              ownerID:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: recurringjobs.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: RecurringJob
+    listKind: RecurringJobList
+    plural: recurringjobs
+    shortNames:
+    - lhrj
+    singular: recurringjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Sets groupings to the jobs. When set to "default" group will be
+        added to the volume label when no other job label exist in volume
+      jsonPath: .spec.groups
+      name: Groups
+      type: string
+    - description: Should be one of "backup" or "snapshot"
+      jsonPath: .spec.task
+      name: Task
+      type: string
+    - description: The cron expression represents recurring job scheduling
+      jsonPath: .spec.cron
+      name: Cron
+      type: string
+    - description: The number of snapshots/backups to keep for the volume
+      jsonPath: .spec.retain
+      name: Retain
+      type: integer
+    - description: The concurrent job to run by each cron job
+      jsonPath: .spec.concurrency
+      name: Concurrency
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Specify the labels
+      jsonPath: .spec.labels
+      name: Labels
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RecurringJob is where Longhorn stores recurring job object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Sets groupings to the jobs. When set to "default" group will be
+        added to the volume label when no other job label exist in volume
+      jsonPath: .spec.groups
+      name: Groups
+      type: string
+    - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup",
+        "snapshot-delete", "backup", "backup-force-create", "filesystem-trim" or "system-backup"
+      jsonPath: .spec.task
+      name: Task
+      type: string
+    - description: The cron expression represents recurring job scheduling
+      jsonPath: .spec.cron
+      name: Cron
+      type: string
+    - description: The number of snapshots/backups to keep for the volume
+      jsonPath: .spec.retain
+      name: Retain
+      type: integer
+    - description: The concurrent job to run by each cron job
+      jsonPath: .spec.concurrency
+      name: Concurrency
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Specify the labels
+      jsonPath: .spec.labels
+      name: Labels
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: RecurringJob is where Longhorn stores recurring job object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RecurringJobSpec defines the desired state of the Longhorn
+              recurring job
+            properties:
+              concurrency:
+                description: The concurrency of taking the snapshot/backup.
+                type: integer
+              cron:
+                description: The cron setting.
+                type: string
+              groups:
+                description: The recurring job group.
+                items:
+                  type: string
+                type: array
+              labels:
+                additionalProperties:
+                  type: string
+                description: The label of the snapshot/backup.
+                type: object
+              name:
+                description: The recurring job name.
+                type: string
+              parameters:
+                additionalProperties:
+                  type: string
+                description: |-
+                  The parameters of the snapshot/backup.
+                  Support parameters: "full-backup-interval", "volume-backup-policy".
+                type: object
+              retain:
+                description: The retain count of the snapshot/backup.
+                type: integer
+              task:
+                description: |-
+                  The recurring job task.
+                  Can be "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup", "backup-force-create", "filesystem-trim" or "system-backup".
+                enum:
+                - snapshot
+                - snapshot-force-create
+                - snapshot-cleanup
+                - snapshot-delete
+                - backup
+                - backup-force-create
+                - filesystem-trim
+                - system-backup
+                type: string
+            type: object
+          status:
+            description: RecurringJobStatus defines the observed state of the Longhorn
+              recurring job
+            properties:
+              executionCount:
+                description: The number of jobs that have been triggered.
+                type: integer
+              ownerID:
+                description: The owner ID which is responsible to reconcile this recurring
+                  job CR.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: replicas.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Replica
+    listKind: ReplicaList
+    plural: replicas
+    shortNames:
+    - lhr
+    singular: replica
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The current state of the replica
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The node that the replica is on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - description: The disk that the replica is on
+      jsonPath: .spec.diskID
+      name: Disk
+      type: string
+    - description: The instance manager of the replica
+      jsonPath: .status.instanceManagerName
+      name: InstanceManager
+      type: string
+    - description: The current image of the replica
+      jsonPath: .status.currentImage
+      name: Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Replica is where Longhorn stores replica object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The data engine of the replica
+      jsonPath: .spec.dataEngine
+      name: Data Engine
+      type: string
+    - description: The current state of the replica
+      jsonPath: .status.currentState
+      name: State
+      type: string
+    - description: The node that the replica is on
+      jsonPath: .spec.nodeID
+      name: Node
+      type: string
+    - description: The disk that the replica is on
+      jsonPath: .spec.diskID
+      name: Disk
+      type: string
+    - description: The instance manager of the replica
+      jsonPath: .status.instanceManagerName
+      name: InstanceManager
+      type: string
+    - description: The current image of the replica
+      jsonPath: .status.currentImage
+      name: Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Replica is where Longhorn stores replica object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReplicaSpec defines the desired state of the Longhorn replica
+            properties:
+              active:
+                type: boolean
+              backendStoreDriver:
+                description: Deprecated:Replaced by field `dataEngine`.
+                type: string
+              backingImage:
+                type: string
+              dataDirectoryName:
+                type: string
+              dataEngine:
+                enum:
+                - v1
+                - v2
+                type: string
+              desireState:
+                type: string
+              diskID:
+                type: string
+              diskPath:
+                type: string
+              engineImage:
+                description: 'Deprecated: Replaced by field `image`.'
+                type: string
+              engineName:
+                type: string
+              evictionRequested:
+                type: boolean
+              failedAt:
+                description: |-
+                  FailedAt is set when a running replica fails or when a running engine is unable to use a replica for any reason.
+                  FailedAt indicates the time the failure occurred. When FailedAt is set, a replica is likely to have useful
+                  (though possibly stale) data. A replica with FailedAt set must be rebuilt from a non-failed replica (or it can
+                  be used in a salvage if all replicas are failed). FailedAt is cleared before a rebuild or salvage. FailedAt may
+                  be later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume
+                  controller acknowledges the change.
+                type: string
+              hardNodeAffinity:
+                type: string
+              healthyAt:
+                description: |-
+                  HealthyAt is set the first time a replica becomes read/write in an engine after creation or rebuild. HealthyAt
+                  indicates the time the last successful rebuild occurred. When HealthyAt is set, a replica is likely to have
+                  useful (though possibly stale) data. HealthyAt is cleared before a rebuild. HealthyAt may be later than the
+                  corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller
+                  acknowledges the change.
+                type: string
+              image:
+                type: string
+              lastFailedAt:
+                description: |-
+                  LastFailedAt is always set at the same time as FailedAt. Unlike FailedAt, LastFailedAt is never cleared.
+                  LastFailedAt is not a reliable indicator of the state of a replica's data. For example, a replica with
+                  LastFailedAt may already be healthy and in use again. However, because it is never cleared, it can be compared to
+                  LastHealthyAt to help prevent dangerous replica deletion in some corner cases. LastFailedAt may be later than the
+                  corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller
+                  acknowledges the change.
+                type: string
+              lastHealthyAt:
+                description: |-
+                  LastHealthyAt is set every time a replica becomes read/write in an engine. Unlike HealthyAt, LastHealthyAt is
+                  never cleared. LastHealthyAt is not a reliable indicator of the state of a replica's data. For example, a
+                  replica with LastHealthyAt set may be in the middle of a rebuild. However, because it is never cleared, it can be
+                  compared to LastFailedAt to help prevent dangerous replica deletion in some corner cases. LastHealthyAt may be
+                  later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume
+                  controller acknowledges the change.
+                type: string
+              logRequested:
+                type: boolean
+              migrationEngineName:
+                description: |-
+                  MigrationEngineName is indicating the migrating engine which current connected to this replica. This is only
+                  used for live migration of v2 data engine
+                type: string
+              nodeID:
+                type: string
+              rebuildRetryCount:
+                type: integer
+              revisionCounterDisabled:
+                type: boolean
+              salvageRequested:
+                type: boolean
+              snapshotMaxCount:
+                type: integer
+              snapshotMaxSize:
+                format: int64
+                type: string
+              unmapMarkDiskChainRemovedEnabled:
+                type: boolean
+              volumeName:
+                type: string
+              volumeSize:
+                format: int64
+                type: string
+            type: object
+          status:
+            description: ReplicaStatus defines the observed state of the Longhorn
+              replica
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              currentImage:
+                type: string
+              currentState:
+                type: string
+              evictionRequested:
+                description: 'Deprecated: Replaced by field `spec.evictionRequested`.'
+                type: boolean
+              instanceManagerName:
+                type: string
+              ip:
+                type: string
+              logFetched:
+                type: boolean
+              ownerID:
+                type: string
+              port:
+                type: integer
+              salvageExecuted:
+                type: boolean
+              started:
+                type: boolean
+              storageIP:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: settings.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Setting
+    listKind: SettingList
+    plural: settings
+    shortNames:
+    - lhs
+    singular: setting
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The value of the setting
+      jsonPath: .value
+      name: Value
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Setting is where Longhorn stores setting object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          value:
+            type: string
+        required:
+        - value
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The value of the setting
+      jsonPath: .value
+      name: Value
+      type: string
+    - description: The setting is applied
+      jsonPath: .status.applied
+      name: Applied
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Setting is where Longhorn stores setting object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          status:
+            description: The status of the setting.
+            properties:
+              applied:
+                description: The setting is applied.
+                type: boolean
+            required:
+            - applied
+            type: object
+          value:
+            description: The value of the setting.
+            type: string
+        required:
+        - value
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: sharemanagers.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: ShareManager
+    listKind: ShareManagerList
+    plural: sharemanagers
+    shortNames:
+    - lhsm
+    singular: sharemanager
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The state of the share manager
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The node that the share manager is owned by
+      jsonPath: .status.ownerID
+      name: Node
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ShareManager is where Longhorn stores share manager object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The state of the share manager
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The node that the share manager is owned by
+      jsonPath: .status.ownerID
+      name: Node
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: ShareManager is where Longhorn stores share manager object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ShareManagerSpec defines the desired state of the Longhorn
+              share manager
+            properties:
+              image:
+                description: Share manager image used for creating a share manager
+                  pod
+                type: string
+            type: object
+          status:
+            description: ShareManagerStatus defines the observed state of the Longhorn
+              share manager
+            properties:
+              endpoint:
+                description: NFS endpoint that can access the mounted filesystem of
+                  the volume
+                type: string
+              ownerID:
+                description: The node ID on which the controller is responsible to
+                  reconcile this share manager resource
+                type: string
+              state:
+                description: The state of the share manager resource
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: snapshots.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Snapshot
+    listKind: SnapshotList
+    plural: snapshots
+    shortNames:
+    - lhsnap
+    singular: snapshot
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The volume that this snapshot belongs to
+      jsonPath: .spec.volume
+      name: Volume
+      type: string
+    - description: Timestamp when the point-in-time snapshot was taken
+      jsonPath: .status.creationTime
+      name: CreationTime
+      type: string
+    - description: Indicates if the snapshot is ready to be used to restore/backup
+        a volume
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: Represents the minimum size of volume required to rehydrate from
+        this snapshot
+      jsonPath: .status.restoreSize
+      name: RestoreSize
+      type: string
+    - description: The actual size of the snapshot
+      jsonPath: .status.size
+      name: Size
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Snapshot is the Schema for the snapshots API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SnapshotSpec defines the desired state of Longhorn Snapshot
+            properties:
+              createSnapshot:
+                description: require creating a new snapshot
+                type: boolean
+              labels:
+                additionalProperties:
+                  type: string
+                description: The labels of snapshot
+                nullable: true
+                type: object
+              volume:
+                description: |-
+                  the volume that this snapshot belongs to.
+                  This field is immutable after creation.
+                type: string
+            required:
+            - volume
+            type: object
+          status:
+            description: SnapshotStatus defines the observed state of Longhorn Snapshot
+            properties:
+              checksum:
+                type: string
+              children:
+                additionalProperties:
+                  type: boolean
+                nullable: true
+                type: object
+              creationTime:
+                type: string
+              error:
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                nullable: true
+                type: object
+              markRemoved:
+                type: boolean
+              ownerID:
+                type: string
+              parent:
+                type: string
+              readyToUse:
+                type: boolean
+              restoreSize:
+                format: int64
+                type: integer
+              size:
+                format: int64
+                type: integer
+              userCreated:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: supportbundles.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SupportBundle
+    listKind: SupportBundleList
+    plural: supportbundles
+    shortNames:
+    - lhbundle
+    singular: supportbundle
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The state of the support bundle
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The issue URL
+      jsonPath: .spec.issueURL
+      name: Issue
+      type: string
+    - description: A brief description of the issue
+      jsonPath: .spec.description
+      name: Description
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: SupportBundle is where Longhorn stores support bundle object
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SupportBundleSpec defines the desired state of the Longhorn
+              SupportBundle
+            properties:
+              description:
+                description: A brief description of the issue
+                type: string
+              issueURL:
+                description: The issue URL
+                nullable: true
+                type: string
+              nodeID:
+                description: The preferred responsible controller node ID.
+                type: string
+            required:
+            - description
+            type: object
+          status:
+            description: SupportBundleStatus defines the observed state of the Longhorn
+              SupportBundle
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                type: array
+              filename:
+                type: string
+              filesize:
+                format: int64
+                type: integer
+              image:
+                description: The support bundle manager image
+                type: string
+              managerIP:
+                description: The support bundle manager IP
+                type: string
+              ownerID:
+                description: The current responsible controller node ID
+                type: string
+              progress:
+                type: integer
+              state:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: systembackups.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SystemBackup
+    listKind: SystemBackupList
+    plural: systembackups
+    shortNames:
+    - lhsb
+    singular: systembackup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The system backup Longhorn version
+      jsonPath: .status.version
+      name: Version
+      type: string
+    - description: The system backup state
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The system backup creation time
+      jsonPath: .status.createdAt
+      name: Created
+      type: string
+    - description: The last time that the system backup was synced into the cluster
+      jsonPath: .status.lastSyncedAt
+      name: LastSyncedAt
+      type: string
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: SystemBackup is where Longhorn stores system backup object
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SystemBackupSpec defines the desired state of the Longhorn
+              SystemBackup
+            properties:
+              volumeBackupPolicy:
+                description: |-
+                  The create volume backup policy
+                  Can be "if-not-present", "always" or "disabled"
+                nullable: true
+                type: string
+            type: object
+          status:
+            description: SystemBackupStatus defines the observed state of the Longhorn
+              SystemBackup
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              createdAt:
+                description: The system backup creation time.
+                format: date-time
+                type: string
+              gitCommit:
+                description: The saved Longhorn manager git commit.
+                nullable: true
+                type: string
+              lastSyncedAt:
+                description: The last time that the system backup was synced into
+                  the cluster.
+                format: date-time
+                nullable: true
+                type: string
+              managerImage:
+                description: The saved manager image.
+                type: string
+              ownerID:
+                description: The node ID of the responsible controller to reconcile
+                  this SystemBackup.
+                type: string
+              state:
+                description: The system backup state.
+                type: string
+              version:
+                description: The saved Longhorn version.
+                nullable: true
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: systemrestores.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SystemRestore
+    listKind: SystemRestoreList
+    plural: systemrestores
+    shortNames:
+    - lhsr
+    singular: systemrestore
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The system restore state
+      jsonPath: .status.state
+      name: State
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: SystemRestore is where Longhorn stores system restore object
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SystemRestoreSpec defines the desired state of the Longhorn
+              SystemRestore
+            properties:
+              systemBackup:
+                description: The system backup name in the object store.
+                type: string
+            required:
+            - systemBackup
+            type: object
+          status:
+            description: SystemRestoreStatus defines the observed state of the Longhorn
+              SystemRestore
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              ownerID:
+                description: The node ID of the responsible controller to reconcile
+                  this SystemRestore.
+                type: string
+              sourceURL:
+                description: The source system backup URL.
+                type: string
+              state:
+                description: The system restore state.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: volumeattachments.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: VolumeAttachment
+    listKind: VolumeAttachmentList
+    plural: volumeattachments
+    shortNames:
+    - lhva
+    singular: volumeattachment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: VolumeAttachment stores attachment information of a Longhorn
+          volume
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeAttachmentSpec defines the desired state of Longhorn
+              VolumeAttachment
+            properties:
+              attachmentTickets:
+                additionalProperties:
+                  properties:
+                    generation:
+                      description: |-
+                        A sequence number representing a specific generation of the desired state.
+                        Populated by the system. Read-only.
+                      format: int64
+                      type: integer
+                    id:
+                      description: The unique ID of this attachment. Used to differentiate
+                        different attachments of the same volume.
+                      type: string
+                    nodeID:
+                      description: The node that this attachment is requesting
+                      type: string
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: Optional additional parameter for this attachment
+                      type: object
+                    type:
+                      type: string
+                  type: object
+                type: object
+              volume:
+                description: The name of Longhorn volume of this VolumeAttachment
+                type: string
+            required:
+            - volume
+            type: object
+          status:
+            description: VolumeAttachmentStatus defines the observed state of Longhorn
+              VolumeAttachment
+            properties:
+              attachmentTicketStatuses:
+                additionalProperties:
+                  properties:
+                    conditions:
+                      description: Record any error when trying to fulfill this attachment
+                      items:
+                        properties:
+                          lastProbeTime:
+                            description: Last time we probed the condition.
+                            type: string
+                          lastTransitionTime:
+                            description: Last time the condition transitioned from
+                              one status to another.
+                            type: string
+                          message:
+                            description: Human-readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            description: |-
+                              Status is the status of the condition.
+                              Can be True, False, Unknown.
+                            type: string
+                          type:
+                            description: Type is the type of the condition.
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                    generation:
+                      description: |-
+                        A sequence number representing a specific generation of the desired state.
+                        Populated by the system. Read-only.
+                      format: int64
+                      type: integer
+                    id:
+                      description: The unique ID of this attachment. Used to differentiate
+                        different attachments of the same volume.
+                      type: string
+                    satisfied:
+                      description: Indicate whether this attachment ticket has been
+                        satisfied
+                      type: boolean
+                  required:
+                  - conditions
+                  - satisfied
+                  type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: longhorn/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    longhorn-manager: ""
+  name: volumes.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
+  group: longhorn.io
+  names:
+    kind: Volume
+    listKind: VolumeList
+    plural: volumes
+    shortNames:
+    - lhv
+    singular: volume
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The state of the volume
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The robustness of the volume
+      jsonPath: .status.robustness
+      name: Robustness
+      type: string
+    - description: The scheduled condition of the volume
+      jsonPath: .status.conditions['scheduled']['status']
+      name: Scheduled
+      type: string
+    - description: The size of the volume
+      jsonPath: .spec.size
+      name: Size
+      type: string
+    - description: The node that the volume is currently attaching to
+      jsonPath: .status.currentNodeID
+      name: Node
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Volume is where Longhorn stores volume object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The data engine of the volume
+      jsonPath: .spec.dataEngine
+      name: Data Engine
+      type: string
+    - description: The state of the volume
+      jsonPath: .status.state
+      name: State
+      type: string
+    - description: The robustness of the volume
+      jsonPath: .status.robustness
+      name: Robustness
+      type: string
+    - description: The scheduled condition of the volume
+      jsonPath: .status.conditions[?(@.type=='Schedulable')].status
+      name: Scheduled
+      type: string
+    - description: The size of the volume
+      jsonPath: .spec.size
+      name: Size
+      type: string
+    - description: The node that the volume is currently attaching to
+      jsonPath: .status.currentNodeID
+      name: Node
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: Volume is where Longhorn stores volume object.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeSpec defines the desired state of the Longhorn volume
+            properties:
+              Standby:
+                type: boolean
+              accessMode:
+                enum:
+                - rwo
+                - rwx
+                type: string
+              backendStoreDriver:
+                description: Deprecated:Replaced by field `dataEngine`.'
+                type: string
+              backingImage:
+                type: string
+              backupCompressionMethod:
+                enum:
+                - none
+                - lz4
+                - gzip
+                type: string
+              backupTargetName:
+                description: The backup target name that the volume will be backed
+                  up to or is synced.
+                type: string
+              dataEngine:
+                enum:
+                - v1
+                - v2
+                type: string
+              dataLocality:
+                enum:
+                - disabled
+                - best-effort
+                - strict-local
+                type: string
+              dataSource:
+                type: string
+              disableFrontend:
+                type: boolean
+              diskSelector:
+                items:
+                  type: string
+                type: array
+              encrypted:
+                type: boolean
+              engineImage:
+                description: 'Deprecated: Replaced by field `image`.'
+                type: string
+              freezeFilesystemForSnapshot:
+                description: Setting that freezes the filesystem on the root partition
+                  before a snapshot is created.
+                enum:
+                - ignored
+                - enabled
+                - disabled
+                type: string
+              fromBackup:
+                type: string
+              frontend:
+                enum:
+                - blockdev
+                - iscsi
+                - nvmf
+                - ""
+                type: string
+              image:
+                type: string
+              lastAttachedBy:
+                type: string
+              migratable:
+                type: boolean
+              migrationNodeID:
+                type: string
+              nodeID:
+                type: string
+              nodeSelector:
+                items:
+                  type: string
+                type: array
+              numberOfReplicas:
+                type: integer
+              replicaAutoBalance:
+                enum:
+                - ignored
+                - disabled
+                - least-effort
+                - best-effort
+                type: string
+              replicaDiskSoftAntiAffinity:
+                description: Replica disk soft anti affinity of the volume. Set enabled
+                  to allow replicas to be scheduled in the same disk.
+                enum:
+                - ignored
+                - enabled
+                - disabled
+                type: string
+              replicaSoftAntiAffinity:
+                description: Replica soft anti affinity of the volume. Set enabled
+                  to allow replicas to be scheduled on the same node.
+                enum:
+                - ignored
+                - enabled
+                - disabled
+                type: string
+              replicaZoneSoftAntiAffinity:
+                description: Replica zone soft anti affinity of the volume. Set enabled
+                  to allow replicas to be scheduled in the same zone.
+                enum:
+                - ignored
+                - enabled
+                - disabled
+                type: string
+              restoreVolumeRecurringJob:
+                enum:
+                - ignored
+                - enabled
+                - disabled
+                type: string
+              revisionCounterDisabled:
+                type: boolean
+              size:
+                format: int64
+                type: string
+              snapshotDataIntegrity:
+                enum:
+                - ignored
+                - disabled
+                - enabled
+                - fast-check
+                type: string
+              snapshotMaxCount:
+                type: integer
+              snapshotMaxSize:
+                format: int64
+                type: string
+              staleReplicaTimeout:
+                type: integer
+              unmapMarkSnapChainRemoved:
+                enum:
+                - ignored
+                - disabled
+                - enabled
+                type: string
+            type: object
+          status:
+            description: VolumeStatus defines the observed state of the Longhorn volume
+            properties:
+              actualSize:
+                format: int64
+                type: integer
+              cloneStatus:
+                properties:
+                  attemptCount:
+                    type: integer
+                  nextAllowedAttemptAt:
+                    type: string
+                  snapshot:
+                    type: string
+                  sourceVolume:
+                    type: string
+                  state:
+                    type: string
+                type: object
+              conditions:
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: |-
+                        Status is the status of the condition.
+                        Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                nullable: true
+                type: array
+              currentImage:
+                type: string
+              currentMigrationNodeID:
+                description: the node that this volume is currently migrating to
+                type: string
+              currentNodeID:
+                type: string
+              expansionRequired:
+                type: boolean
+              frontendDisabled:
+                type: boolean
+              isStandby:
+                type: boolean
+              kubernetesStatus:
+                properties:
+                  lastPVCRefAt:
+                    type: string
+                  lastPodRefAt:
+                    type: string
+                  namespace:
+                    description: determine if PVC/Namespace is history or not
+                    type: string
+                  pvName:
+                    type: string
+                  pvStatus:
+                    type: string
+                  pvcName:
+                    type: string
+                  workloadsStatus:
+                    description: determine if Pod/Workload is history or not
+                    items:
+                      properties:
+                        podName:
+                          type: string
+                        podStatus:
+                          type: string
+                        workloadName:
+                          type: string
+                        workloadType:
+                          type: string
+                      type: object
+                    nullable: true
+                    type: array
+                type: object
+              lastBackup:
+                type: string
+              lastBackupAt:
+                type: string
+              lastDegradedAt:
+                type: string
+              ownerID:
+                type: string
+              pendingNodeID:
+                description: Deprecated.
+                type: string
+              remountRequestedAt:
+                type: string
+              restoreInitiated:
+                type: boolean
+              restoreRequired:
+                type: boolean
+              robustness:
+                type: string
+              shareEndpoint:
+                type: string
+              shareState:
+                type: string
+              state:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/infrastructure/controllers/base/01-longhorn/03-priorityclass.yaml
+++ b/infrastructure/controllers/base/01-longhorn/03-priorityclass.yaml
@@ -1,0 +1,15 @@
+---
+# Source: longhorn/templates/priorityclass.yaml
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: "longhorn-critical"
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+description: "Ensure Longhorn pods have the highest priority to prevent any unexpected eviction by the Kubernetes scheduler under node pressure"
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000
+

--- a/infrastructure/controllers/base/01-longhorn/03-service-account.yaml
+++ b/infrastructure/controllers/base/01-longhorn/03-service-account.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-service-account
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-ui-service-account
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-support-bundle
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev

--- a/infrastructure/controllers/base/01-longhorn/04-daemonset.yaml
+++ b/infrastructure/controllers/base/01-longhorn/04-daemonset.yaml
@@ -1,0 +1,126 @@
+---
+# Source: longhorn/templates/daemonset-sa.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    app: longhorn-manager
+  name: longhorn-manager
+  namespace: longhorn-system
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.9.0-dev
+        app: longhorn-manager
+    spec:
+      containers:
+      - name: longhorn-manager
+        image: longhornio/longhorn-manager:master-head
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command:
+        - longhorn-manager
+        - -d
+        - daemon
+        - --engine-image
+        - "longhornio/longhorn-engine:master-head"
+        - --instance-manager-image
+        - "longhornio/longhorn-instance-manager:master-head"
+        - --share-manager-image
+        - "longhornio/longhorn-share-manager:master-head"
+        - --backing-image-manager-image
+        - "longhornio/backing-image-manager:master-head"
+        - --support-bundle-manager-image
+        - "longhornio/support-bundle-kit:v0.0.49"
+        - --manager-image
+        - "longhornio/longhorn-manager:master-head"
+        - --service-account
+        - longhorn-service-account
+        - --upgrade-version-check
+        ports:
+        - containerPort: 9500
+          name: manager
+        - containerPort: 9501
+          name: conversion-wh
+        - containerPort: 9502
+          name: admission-wh
+        - containerPort: 9503
+          name: recov-backend
+        readinessProbe:
+          httpGet:
+            path: /v1/healthz
+            port: 9501
+            scheme: HTTPS
+        volumeMounts:
+        - name: boot
+          mountPath: /host/boot/
+          readOnly: true
+        - name: dev
+          mountPath: /host/dev/
+        - name: proc
+          mountPath: /host/proc/
+          readOnly: true
+        - name: etc
+          mountPath: /host/etc/
+          readOnly: true
+        - name: longhorn
+          mountPath: /var/lib/longhorn/
+          mountPropagation: Bidirectional
+        - name: longhorn-grpc-tls
+          mountPath: /tls-files/
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      - name: pre-pull-share-manager-image
+        imagePullPolicy: IfNotPresent
+        image: longhornio/longhorn-share-manager:master-head
+        command: ["sh", "-c", "echo share-manager image pulled && sleep infinity"]
+      volumes:
+      - name: boot
+        hostPath:
+          path: /boot/
+      - name: dev
+        hostPath:
+          path: /dev/
+      - name: proc
+        hostPath:
+          path: /proc/
+      - name: etc
+        hostPath:
+          path: /etc/
+      - name: longhorn
+        hostPath:
+          path: /var/lib/longhorn/
+      - name: longhorn-grpc-tls
+        secret:
+          secretName: longhorn-grpc-tls
+          optional: true
+      priorityClassName: "longhorn-critical"
+      serviceAccountName: longhorn-service-account
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: "100%"

--- a/infrastructure/controllers/base/01-longhorn/04-deployment.yaml
+++ b/infrastructure/controllers/base/01-longhorn/04-deployment.yaml
@@ -1,0 +1,134 @@
+---
+# Source: longhorn/templates/deployment-driver.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: longhorn-driver-deployer
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: longhorn-driver-deployer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.9.0-dev
+        app: longhorn-driver-deployer
+    spec:
+      initContainers:
+        - name: wait-longhorn-manager
+          image: longhornio/longhorn-manager:master-head
+          command: ['sh', '-c', 'while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done']
+      containers:
+        - name: longhorn-driver-deployer
+          image: longhornio/longhorn-manager:master-head
+          imagePullPolicy: IfNotPresent
+          command:
+          - longhorn-manager
+          - -d
+          - deploy-driver
+          - --manager-image
+          - "longhornio/longhorn-manager:master-head"
+          - --manager-url
+          - http://longhorn-backend:9500/v1
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          - name: CSI_ATTACHER_IMAGE
+            value: "longhornio/csi-attacher:v4.8.0"
+          - name: CSI_PROVISIONER_IMAGE
+            value: "longhornio/csi-provisioner:v5.1.0-20241220"
+          - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
+            value: "longhornio/csi-node-driver-registrar:v2.13.0"
+          - name: CSI_RESIZER_IMAGE
+            value: "longhornio/csi-resizer:v1.13.1"
+          - name: CSI_SNAPSHOTTER_IMAGE
+            value: "longhornio/csi-snapshotter:v8.2.0"
+          - name: CSI_LIVENESS_PROBE_IMAGE
+            value: "longhornio/livenessprobe:v2.15.0"
+      priorityClassName: "longhorn-critical"
+      serviceAccountName: longhorn-service-account
+      securityContext:
+        runAsUser: 0
+---
+# Source: longhorn/templates/deployment-ui.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    app: longhorn-ui
+  name: longhorn-ui
+  namespace: longhorn-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: longhorn-ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.9.0-dev
+        app: longhorn-ui
+    spec:
+      serviceAccountName: longhorn-ui-service-account
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - longhorn-ui
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: longhorn-ui
+        image: longhornio/longhorn-ui:master-head
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name : nginx-cache
+          mountPath: /var/cache/nginx/
+        - name : nginx-config
+          mountPath: /var/config/nginx/
+        - name: var-run
+          mountPath: /var/run/
+        ports:
+        - containerPort: 8000
+          name: http
+        env:
+          - name: LONGHORN_MANAGER_IP
+            value: "http://longhorn-backend:9500"
+          - name: LONGHORN_UI_PORT
+            value: "8000"
+      volumes:
+      - emptyDir: {}
+        name: nginx-cache
+      - emptyDir: {}
+        name: nginx-config
+      - emptyDir: {}
+        name: var-run
+      priorityClassName: "longhorn-critical"

--- a/infrastructure/controllers/base/01-longhorn/05-services.yaml
+++ b/infrastructure/controllers/base/01-longhorn/05-services.yaml
@@ -1,0 +1,101 @@
+---
+# Source: longhorn/templates/daemonset-sa.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    app: longhorn-manager
+  name: longhorn-backend
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: longhorn-manager
+  ports:
+  - name: manager
+    port: 9500
+    targetPort: manager
+---
+# Source: longhorn/templates/deployment-ui.yaml
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    app: longhorn-ui
+  name: longhorn-frontend
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: longhorn-ui
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+    nodePort: null
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    app: longhorn-conversion-webhook
+  name: longhorn-conversion-webhook
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    longhorn.io/conversion-webhook: longhorn-conversion-webhook
+  ports:
+  - name: conversion-webhook
+    port: 9501
+    targetPort: conversion-wh
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    app: longhorn-admission-webhook
+  name: longhorn-admission-webhook
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    longhorn.io/admission-webhook: longhorn-admission-webhook
+  ports:
+  - name: admission-webhook
+    port: 9502
+    targetPort: admission-wh
+---
+# Source: longhorn/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.9.0-dev
+    app: longhorn-recovery-backend
+  name: longhorn-recovery-backend
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    longhorn.io/recovery-backend: longhorn-recovery-backend
+  ports:
+  - name: recovery-backend
+    port: 9503
+    targetPort: recov-backend

--- a/infrastructure/controllers/base/01-longhorn/06-ingress.yaml
+++ b/infrastructure/controllers/base/01-longhorn/06-ingress.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: longhorn-ui-ingress
+  namespace: longhorn-system
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: Host(`longhorn-dashboard.tommahs.nl`)
+      priority: 10
+      services:
+        - kind: Service
+          name: longhorn-ui
+          namespace: longhorn-system
+          passHostHeader: true
+          port: 80
+          responseForwarding:
+            flushInterval: 1ms

--- a/infrastructure/controllers/base/01-longhorn/README.md
+++ b/infrastructure/controllers/base/01-longhorn/README.md
@@ -1,0 +1,4 @@
+Workers require: 
+pacman -S open-iscsi
+systemctl enable --now iscsid
+

--- a/infrastructure/controllers/base/01-longhorn/kustomization.yaml
+++ b/infrastructure/controllers/base/01-longhorn/kustomization.yaml
@@ -1,0 +1,12 @@
+# base/kustomization.yaml
+resources:
+  - 01-cluster-role-binding.yaml
+  - 01-cluster-role.yaml
+  - 01-namespace.yaml
+  - 02-config-map.yaml
+  - 02-custom-resource-definition.yaml
+  - 03-priorityclass.yaml
+  - 03-service-account.yaml
+  - 04-daemonset.yaml
+  - 04-deployment.yaml
+  - 05-services.yaml

--- a/infrastructure/controllers/base/01-traefik/01-certificates-pv.yaml
+++ b/infrastructure/controllers/base/01-traefik/01-certificates-pv.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: traefik-certificates-pv
+  namespace: traefik
+spec:
+  capacity:
+    storage: 128Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: certificates
+  nfs:
+    path: /data/nfs/certificates
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1

--- a/infrastructure/controllers/base/01-traefik/02-certificates-pvc.yaml
+++ b/infrastructure/controllers/base/01-traefik/02-certificates-pvc.yaml
@@ -1,0 +1,14 @@
+---
+# 03-backup-pvc.yaml // pathfinderwiki-mariadb-data
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: certificates
+  namespace: traefik
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: certificates
+  resources:
+    requests:
+      storage: 128Mi

--- a/infrastructure/controllers/base/01-traefik/values.yaml
+++ b/infrastructure/controllers/base/01-traefik/values.yaml
@@ -1,0 +1,136 @@
+# Use host network to bind directly to VM's network interface
+#hostNetwork: true
+
+# Set number of replicas
+deployment:
+  replicas: 6
+  # Ensure pods are spread across nodes
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - traefik
+          topologyKey: kubernetes.io/hostname
+
+# Ensure Traefik only runs on worker nodes
+nodeSelector:
+  node-role.kubernetes.io/worker: ""
+
+# Configure tolerations if needed
+tolerations: []
+
+# Configure global settings
+global:
+  checknewversion: false
+  sendanonymoususage: false
+
+# Define entry points for HTTP and HTTPS
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+  websecure:
+    address: ":443"
+  traefik:
+    address: ":9000"
+# Configure ports to bind to host ports 80 and 443
+ports:
+  web:
+    port: 80
+    expose: {}
+    exposedPort: 80
+    protocol: TCP
+  websecure:
+    port: 443
+    expose: {}
+    exposedPort: 443
+    protocol: TCP
+  traefik:
+    port: 9000
+    expose: {}
+    exposedPort: 9000
+    protocol: TCP
+
+# Security settings to allow binding to privileged ports
+securityContext:
+  capabilities:
+    drop: [ALL]
+    add: [NET_BIND_SERVICE]
+  readOnlyRootFilesystem: true
+  runAsNonRoot: false
+  runAsUser: 0
+
+# Enable kubernetes integration
+providers:
+  kubernetesCRD:
+    enabled: true
+    allowCrossNamespace: true
+  kubernetesIngress:
+    enabled: true
+    publishedService:
+      enabled: true
+
+# Enable RBAC
+rbac:
+  enabled: true
+
+# Disable the default service as we're using hostNetwork
+service:
+  enabled: false
+
+# Basic dashboard config
+dashboard:
+  enabled: true
+
+# Traefik IngressRoute configuration
+# Configure dashboard access
+ingressRoute:
+  dashboard:
+    enabled: true
+    # Use the traefik entrypoint
+    entryPoints: ["traefik"]
+    # No host rule - accessible via IP:9000
+    annotations: {}
+    middlewares: []
+    tls: {}
+######
+# This block should be in grafana's base
+#ingressRoute:
+#  grafana:
+#    # This will create a Traefik IngressRoute CRD
+#    enabled: true
+#    # Use both HTTP and HTTPS endpoints
+#    entryPoints: ["web", "websecure"]
+#    # Your domain configuration
+#    match: Host(`grafana-k8s.tommahs.nl`)
+#    # Point to the Grafana service
+#    service:
+#      name: grafana
+#      port: 3000
+##############
+
+# Additional experimental features required for dashboard
+api:
+  dashboard: true
+
+# Add to your existing Traefik configuration
+persistence:
+  enabled: true
+  name: certificates
+  existingClaim: certificates
+  accessMode: ReadWriteMany
+  size: 128Mi
+  path: /data
+
+# Configure the certificate resolvers
+additionalArguments:
+  - "--ping=true"

--- a/infrastructure/controllers/base/02-vault/00-namespace.yaml
+++ b/infrastructure/controllers/base/02-vault/00-namespace.yaml
@@ -1,0 +1,6 @@
+---
+# 00-namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vault-system

--- a/infrastructure/controllers/base/02-vault/01-cluster-role.yaml
+++ b/infrastructure/controllers/base/02-vault/01-cluster-role.yaml
@@ -1,0 +1,30 @@
+---
+# 01-cluster-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vault-server
+rules:
+- apiGroups: [""]
+  resources:
+    - "namespaces"
+    - "pods"
+    - "services"
+    - "secrets"
+    - "serviceaccounts"
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+    - "roles"
+    - "rolebindings"
+    - "clusterroles"
+    - "clusterrolebindings"
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+    - "tokenreviews"
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+    - "subjectaccessreviews"
+  verbs: ["create"]

--- a/infrastructure/controllers/base/02-vault/01-persistent-volumes.yaml
+++ b/infrastructure/controllers/base/02-vault/01-persistent-volumes.yaml
@@ -1,0 +1,41 @@
+---
+# 01-persistent-volumes.yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: vault-data
+  namespace: vault-system
+spec:
+  capacity:
+    storage: 10Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: vault-data
+  nfs:
+    path: /data/nfs/vault/data
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: vault-backup
+  namespace: vault-system
+spec:
+  capacity:
+    storage: 20Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: vault-backup
+  nfs:
+    path: /data/nfs/vault/backup
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1

--- a/infrastructure/controllers/base/02-vault/01-service-account.yaml
+++ b/infrastructure/controllers/base/02-vault/01-service-account.yaml
@@ -1,0 +1,7 @@
+---
+# 01-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault
+  namespace: vault-system

--- a/infrastructure/controllers/base/02-vault/02-cluster-role-binding.yaml
+++ b/infrastructure/controllers/base/02-vault/02-cluster-role-binding.yaml
@@ -1,0 +1,29 @@
+---
+# 02-cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-server-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vault-server
+subjects:
+- kind: ServiceAccount
+  name: vault
+  namespace: vault-system
+---
+# 02-cluster-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault
+  namespace: vault-system
+---

--- a/infrastructure/controllers/base/02-vault/02-configmap.yaml
+++ b/infrastructure/controllers/base/02-vault/02-configmap.yaml
@@ -1,0 +1,24 @@
+---
+# 03-vault-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-config
+  namespace: vault-system
+data:
+  config.hcl: |
+    ui = true
+    
+    storage "file" {
+      path = "/vault/data"
+    }
+
+    listener "tcp" {
+      address = "0.0.0.0:8200"
+      tls_disable = 1  # Enable TLS in production
+    }
+    
+    api_addr = "http://vault.vault-system:8200"
+
+    seal "shamir" {
+    }

--- a/infrastructure/controllers/base/02-vault/02-persistent-volume-claims.yaml
+++ b/infrastructure/controllers/base/02-vault/02-persistent-volume-claims.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-data
+  namespace: vaultwarden
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: vault-data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-backup
+  namespace: vaultwarden
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: vault-backup

--- a/infrastructure/controllers/base/02-vault/03-deployment.yaml
+++ b/infrastructure/controllers/base/02-vault/03-deployment.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vault
+  namespace: vault-system
+spec:
+  serviceName: vault
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vault
+  template:
+    metadata:
+      labels:
+        app: vault
+    spec:
+      serviceAccountName: vault
+      containers:
+      - name: vault
+        image: vault:1.13.3
+        command:
+        - "vault"
+        args:
+        - "server"
+        - "-config=/vault/config/config.hcl"
+        ports:
+        - containerPort: 8200
+          name: http
+        - containerPort: 8201
+          name: internal
+        securityContext:
+          capabilities:
+            add: ["IPC_LOCK"]
+        volumeMounts:
+        - name: vault-config
+          mountPath: /vault/config
+        - name: vault-data
+          mountPath: /vault/data
+        readinessProbe:
+          httpGet:
+            path: /v1/sys/health
+            port: 8200
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /v1/sys/health
+            port: 8200
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+      volumes:
+      - name: vault-config
+        configMap:
+          name: vault-config
+      - name: vault-data
+        persistentVolumeClaim:
+          claimName: vault-data

--- a/infrastructure/controllers/base/02-vault/04-service.yaml
+++ b/infrastructure/controllers/base/02-vault/04-service.yaml
@@ -1,0 +1,17 @@
+---
+# 04-vault-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: vault-system
+spec:
+  selector:
+    app: vault
+  ports:
+  - name: http
+    port: 8200
+    targetPort: 8200
+  - name: internal
+    port: 8201
+    targetPort: 8201

--- a/infrastructure/controllers/base/02-vault/06-backup-cronjob.yaml
+++ b/infrastructure/controllers/base/02-vault/06-backup-cronjob.yaml
@@ -1,0 +1,65 @@
+---
+# 06-backup-cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vault-backup
+  namespace: vault-system
+spec:
+  schedule: "0 2 * * *"  # Run at 2 AM every day
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: vault-backup
+            image: vault:1.13.3
+            command:
+            - /bin/sh
+            - -c
+            - |
+              # Wait for Vault to be available
+              until nc -z vault 8200; do
+                echo "Waiting for Vault to be ready..."
+                sleep 5
+              done
+              
+              # Create backup directory with timestamp
+              BACKUP_DIR="/backup/vault-$(date +%Y%m%d-%H%M%S)"
+              mkdir -p $BACKUP_DIR
+              
+              # Perform Vault backup
+              # Note: This requires VAULT_TOKEN to be set
+              if [ -n "$VAULT_TOKEN" ]; then
+                vault operator raft snapshot save $BACKUP_DIR/vault.snap
+                
+                # Create metadata file
+                echo "Backup created at: $(date)" > $BACKUP_DIR/metadata.txt
+                echo "Vault version: $(vault version)" >> $BACKUP_DIR/metadata.txt
+                
+                # Compress backup
+                tar -czf $BACKUP_DIR.tar.gz -C $BACKUP_DIR .
+                rm -rf $BACKUP_DIR
+              else
+                echo "VAULT_TOKEN not set. Backup failed."
+                exit 1
+              fi
+            env:
+            - name: VAULT_ADDR
+              value: "http://vault:8200"
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: vault-token
+                  key: token
+            volumeMounts:
+            - name: vault-backup
+              mountPath: /backup
+          volumes:
+          - name: vault-backup
+            persistentVolumeClaim:
+              claimName: vault-backup
+          restartPolicy: OnFailure

--- a/infrastructure/controllers/base/02-vault/README.md
+++ b/infrastructure/controllers/base/02-vault/README.md
@@ -1,0 +1,6 @@
+For unlock, run this trice:
+```
+kubectl exec -ti -n vault-system vault-0 -- sh
+/ # VAULT_ADDR=http://127.0.0.1:8200 vault operator unseal
+```
+Put in the codes you got from vault init

--- a/infrastructure/controllers/base/02-vault/kustomization.yaml
+++ b/infrastructure/controllers/base/02-vault/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: vault-system
+resources:
+- 00-namespace.yaml
+- 01-cluster-role.yaml
+- 01-persistent-volumes.yaml
+- 01-service-account.yaml
+- 02-configmap.yaml
+- 02-cluster-role-binding.yaml
+- 02-persistent-volume-claims.yaml
+- 03-deployment.yaml
+- 04-service.yaml
+- 06-backup-cronjob.yaml

--- a/infrastructure/controllers/base/03-cert-manager/00-crds.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/00-crds.yaml
@@ -1,0 +1,12161 @@
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Source: cert-manager/templates/crds.yaml
+#
+# START crd
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificaterequests.cert-manager.io
+  # START annotations
+  annotations:
+    helm.sh/resource-policy: keep
+  # END annotations
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  group: cert-manager.io
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+      - cr
+      - crs
+    singular: certificaterequest
+    categories:
+      - cert-manager
+  scope: Namespaced
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Approved")].status
+          name: Approved
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Denied")].status
+          name: Denied
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          type: string
+        - jsonPath: .spec.username
+          name: Requester
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: |-
+            A CertificateRequest is used to request a signed certificate from one of the
+            configured issuers.
+
+            All fields within the CertificateRequest's `spec` are immutable after creation.
+            A CertificateRequest will either succeed or fail, as denoted by its `Ready` status
+            condition and its `status.failureTime` field.
+
+            A CertificateRequest is a one-shot resource, meaning it represents a single
+            point in time request for a certificate and cannot be re-used.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired state of the CertificateRequest resource.
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - issuerRef
+                - request
+              properties:
+                duration:
+                  description: |-
+                    Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                    issuer may choose to ignore the requested duration, just like any other
+                    requested attribute.
+                  type: string
+                extra:
+                  description: |-
+                    Extra contains extra attributes of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+                groups:
+                  description: |-
+                    Groups contains group membership of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: array
+                  items:
+                    type: string
+                  x-kubernetes-list-type: atomic
+                isCA:
+                  description: |-
+                    Requested basic constraints isCA value. Note that the issuer may choose
+                    to ignore the requested isCA value, just like any other requested attribute.
+
+                    NOTE: If the CSR in the `Request` field has a BasicConstraints extension,
+                    it must have the same isCA value as specified here.
+
+                    If true, this will automatically add the `cert sign` usage to the list
+                    of requested `usages`.
+                  type: boolean
+                issuerRef:
+                  description: |-
+                    Reference to the issuer responsible for issuing the certificate.
+                    If the issuer is namespace-scoped, it must be in the same namespace
+                    as the Certificate. If the issuer is cluster-scoped, it can be used
+                    from any namespace.
+
+                    The `name` field of the reference must always be specified.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                request:
+                  description: |-
+                    The PEM-encoded X.509 certificate signing request to be submitted to the
+                    issuer for signing.
+
+                    If the CSR has a BasicConstraints extension, its isCA attribute must
+                    match the `isCA` value of this CertificateRequest.
+                    If the CSR has a KeyUsage extension, its key usages must match the
+                    key usages in the `usages` field of this CertificateRequest.
+                    If the CSR has a ExtKeyUsage extension, its extended key usages
+                    must match the extended key usages in the `usages` field of this
+                    CertificateRequest.
+                  type: string
+                  format: byte
+                uid:
+                  description: |-
+                    UID contains the uid of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: string
+                usages:
+                  description: |-
+                    Requested key usages and extended key usages.
+
+                    NOTE: If the CSR in the `Request` field has uses the KeyUsage or
+                    ExtKeyUsage extension, these extensions must have the same values
+                    as specified here without any additional values.
+
+                    If unset, defaults to `digital signature` and `key encipherment`.
+                  type: array
+                  items:
+                    description: |-
+                      KeyUsage specifies valid usage contexts for keys.
+                      See:
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                      Valid KeyUsage values are as follows:
+                      "signing",
+                      "digital signature",
+                      "content commitment",
+                      "key encipherment",
+                      "key agreement",
+                      "data encipherment",
+                      "cert sign",
+                      "crl sign",
+                      "encipher only",
+                      "decipher only",
+                      "any",
+                      "server auth",
+                      "client auth",
+                      "code signing",
+                      "email protection",
+                      "s/mime",
+                      "ipsec end system",
+                      "ipsec tunnel",
+                      "ipsec user",
+                      "timestamping",
+                      "ocsp signing",
+                      "microsoft sgc",
+                      "netscape sgc"
+                    type: string
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+                username:
+                  description: |-
+                    Username contains the name of the user that created the CertificateRequest.
+                    Populated by the cert-manager webhook on creation and immutable.
+                  type: string
+            status:
+              description: |-
+                Status of the CertificateRequest.
+                This is set and managed automatically.
+                Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                ca:
+                  description: |-
+                    The PEM encoded X.509 certificate of the signer, also known as the CA
+                    (Certificate Authority).
+                    This is set on a best-effort basis by different issuers.
+                    If not set, the CA is assumed to be unknown/not available.
+                  type: string
+                  format: byte
+                certificate:
+                  description: |-
+                    The PEM encoded X.509 certificate resulting from the certificate
+                    signing request.
+                    If not set, the CertificateRequest has either not been completed or has
+                    failed. More information on failure can be found by checking the
+                    `conditions` field.
+                  type: string
+                  format: byte
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of a CertificateRequest.
+                    Known condition types are `Ready`, `InvalidRequest`, `Approved` and `Denied`.
+                  type: array
+                  items:
+                    description: CertificateRequestCondition contains condition information for a CertificateRequest.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: |-
+                          Type of the condition, known values are (`Ready`, `InvalidRequest`,
+                          `Approved`, `Denied`).
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failureTime:
+                  description: |-
+                    FailureTime stores the time that this CertificateRequest failed. This is
+                    used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+      served: true
+      storage: true
+
+# END crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.cert-manager.io
+  # START annotations
+  annotations:
+    helm.sh/resource-policy: keep
+  # END annotations
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+      - cert
+      - certs
+    singular: certificate
+    categories:
+      - cert-manager
+  scope: Namespaced
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.secretName
+          name: Secret
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: |-
+            A Certificate resource should be created to ensure an up to date and signed
+            X.509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`.
+
+            The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`).
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Specification of the desired state of the Certificate resource.
+                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - issuerRef
+                - secretName
+              properties:
+                additionalOutputFormats:
+                  description: |-
+                    Defines extra output formats of the private key and signed certificate chain
+                    to be written to this Certificate's target Secret.
+
+                    This is a Beta Feature enabled by default. It can be disabled with the
+                    `--feature-gates=AdditionalCertificateOutputFormats=false` option set on both
+                    the controller and webhook components.
+                  type: array
+                  items:
+                    description: |-
+                      CertificateAdditionalOutputFormat defines an additional output format of a
+                      Certificate resource. These contain supplementary data formats of the signed
+                      certificate chain and paired private key.
+                    type: object
+                    required:
+                      - type
+                    properties:
+                      type:
+                        description: |-
+                          Type is the name of the format type that should be written to the
+                          Certificate's target Secret.
+                        type: string
+                        enum:
+                          - DER
+                          - CombinedPEM
+                commonName:
+                  description: |-
+                    Requested common name X509 certificate subject attribute.
+                    More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                    NOTE: TLS clients will ignore this value when any subject alternative name is
+                    set (see https://tools.ietf.org/html/rfc6125#section-6.4.4).
+
+                    Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
+                    Cannot be set if the `literalSubject` field is set.
+                  type: string
+                dnsNames:
+                  description: Requested DNS subject alternative names.
+                  type: array
+                  items:
+                    type: string
+                duration:
+                  description: |-
+                    Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                    issuer may choose to ignore the requested duration, just like any other
+                    requested attribute.
+
+                    If unset, this defaults to 90 days.
+                    Minimum accepted duration is 1 hour.
+                    Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                  type: string
+                emailAddresses:
+                  description: Requested email subject alternative names.
+                  type: array
+                  items:
+                    type: string
+                encodeUsagesInRequest:
+                  description: |-
+                    Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.
+
+                    This option defaults to true, and should only be disabled if the target
+                    issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
+                  type: boolean
+                ipAddresses:
+                  description: Requested IP address subject alternative names.
+                  type: array
+                  items:
+                    type: string
+                isCA:
+                  description: |-
+                    Requested basic constraints isCA value.
+                    The isCA value is used to set the `isCA` field on the created CertificateRequest
+                    resources. Note that the issuer may choose to ignore the requested isCA value, just
+                    like any other requested attribute.
+
+                    If true, this will automatically add the `cert sign` usage to the list
+                    of requested `usages`.
+                  type: boolean
+                issuerRef:
+                  description: |-
+                    Reference to the issuer responsible for issuing the certificate.
+                    If the issuer is namespace-scoped, it must be in the same namespace
+                    as the Certificate. If the issuer is cluster-scoped, it can be used
+                    from any namespace.
+
+                    The `name` field of the reference must always be specified.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                keystores:
+                  description: Additional keystore output formats to be stored in the Certificate's Secret.
+                  type: object
+                  properties:
+                    jks:
+                      description: |-
+                        JKS configures options for storing a JKS keystore in the
+                        `spec.secretName` Secret resource.
+                      type: object
+                      required:
+                        - create
+                      properties:
+                        alias:
+                          description: |-
+                            Alias specifies the alias of the key in the keystore, required by the JKS format.
+                            If not provided, the default alias `certificate` will be used.
+                          type: string
+                        create:
+                          description: |-
+                            Create enables JKS keystore creation for the Certificate.
+                            If true, a file named `keystore.jks` will be created in the target
+                            Secret resource, encrypted using the password stored in
+                            `passwordSecretRef` or `password`.
+                            The keystore file will be updated immediately.
+                            If the issuer provided a CA certificate, a file named `truststore.jks`
+                            will also be created in the target Secret resource, encrypted using the
+                            password stored in `passwordSecretRef`
+                            containing the issuing Certificate Authority
+                          type: boolean
+                        password:
+                          description: |-
+                            Password provides a literal password used to encrypt the JKS keystore.
+                            Mutually exclusive with passwordSecretRef.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          type: string
+                        passwordSecretRef:
+                          description: |-
+                            PasswordSecretRef is a reference to a non-empty key in a Secret resource
+                            containing the password used to encrypt the JKS keystore.
+                            Mutually exclusive with password.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                    pkcs12:
+                      description: |-
+                        PKCS12 configures options for storing a PKCS12 keystore in the
+                        `spec.secretName` Secret resource.
+                      type: object
+                      required:
+                        - create
+                      properties:
+                        create:
+                          description: |-
+                            Create enables PKCS12 keystore creation for the Certificate.
+                            If true, a file named `keystore.p12` will be created in the target
+                            Secret resource, encrypted using the password stored in
+                            `passwordSecretRef` or in `password`.
+                            The keystore file will be updated immediately.
+                            If the issuer provided a CA certificate, a file named `truststore.p12` will
+                            also be created in the target Secret resource, encrypted using the
+                            password stored in `passwordSecretRef` containing the issuing Certificate
+                            Authority
+                          type: boolean
+                        password:
+                          description: |-
+                            Password provides a literal password used to encrypt the PKCS#12 keystore.
+                            Mutually exclusive with passwordSecretRef.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          type: string
+                        passwordSecretRef:
+                          description: |-
+                            PasswordSecretRef is a reference to a non-empty key in a Secret resource
+                            containing the password used to encrypt the PKCS#12 keystore.
+                            Mutually exclusive with password.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                        profile:
+                          description: |-
+                            Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
+                            used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+
+                            If provided, allowed values are:
+                            `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                            `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                            `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+                            (eg. because of company policy). Please note that the security of the algorithm is not that important
+                            in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                          type: string
+                          enum:
+                            - LegacyRC2
+                            - LegacyDES
+                            - Modern2023
+                literalSubject:
+                  description: |-
+                    Requested X.509 certificate subject, represented using the LDAP "String
+                    Representation of a Distinguished Name" [1].
+                    Important: the LDAP string format also specifies the order of the attributes
+                    in the subject, this is important when issuing certs for LDAP authentication.
+                    Example: `CN=foo,DC=corp,DC=example,DC=com`
+                    More info [1]: https://datatracker.ietf.org/doc/html/rfc4514
+                    More info: https://github.com/cert-manager/cert-manager/issues/3203
+                    More info: https://github.com/cert-manager/cert-manager/issues/4424
+
+                    Cannot be set if the `subject` or `commonName` field is set.
+                  type: string
+                nameConstraints:
+                  description: |-
+                    x.509 certificate NameConstraint extension which MUST NOT be used in a non-CA certificate.
+                    More Info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
+
+                    This is an Alpha Feature and is only enabled with the
+                    `--feature-gates=NameConstraints=true` option set on both
+                    the controller and webhook components.
+                  type: object
+                  properties:
+                    critical:
+                      description: if true then the name constraints are marked critical.
+                      type: boolean
+                    excluded:
+                      description: |-
+                        Excluded contains the constraints which must be disallowed. Any name matching a
+                        restriction in the excluded field is invalid regardless
+                        of information appearing in the permitted
+                      type: object
+                      properties:
+                        dnsDomains:
+                          description: DNSDomains is a list of DNS domains that are permitted or excluded.
+                          type: array
+                          items:
+                            type: string
+                        emailAddresses:
+                          description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
+                          type: array
+                          items:
+                            type: string
+                        ipRanges:
+                          description: |-
+                            IPRanges is a list of IP Ranges that are permitted or excluded.
+                            This should be a valid CIDR notation.
+                          type: array
+                          items:
+                            type: string
+                        uriDomains:
+                          description: URIDomains is a list of URI domains that are permitted or excluded.
+                          type: array
+                          items:
+                            type: string
+                    permitted:
+                      description: Permitted contains the constraints in which the names must be located.
+                      type: object
+                      properties:
+                        dnsDomains:
+                          description: DNSDomains is a list of DNS domains that are permitted or excluded.
+                          type: array
+                          items:
+                            type: string
+                        emailAddresses:
+                          description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
+                          type: array
+                          items:
+                            type: string
+                        ipRanges:
+                          description: |-
+                            IPRanges is a list of IP Ranges that are permitted or excluded.
+                            This should be a valid CIDR notation.
+                          type: array
+                          items:
+                            type: string
+                        uriDomains:
+                          description: URIDomains is a list of URI domains that are permitted or excluded.
+                          type: array
+                          items:
+                            type: string
+                otherNames:
+                  description: |-
+                    `otherNames` is an escape hatch for SAN that allows any type. We currently restrict the support to string like otherNames, cf RFC 5280 p 37
+                    Any UTF8 String valued otherName can be passed with by setting the keys oid: x.x.x.x and UTF8Value: somevalue for `otherName`.
+                    Most commonly this would be UPN set with oid: 1.3.6.1.4.1.311.20.2.3
+                    You should ensure that any OID passed is valid for the UTF8String type as we do not explicitly validate this.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      oid:
+                        description: |-
+                          OID is the object identifier for the otherName SAN.
+                          The object identifier must be expressed as a dotted string, for
+                          example, "1.2.840.113556.1.4.221".
+                        type: string
+                      utf8Value:
+                        description: |-
+                          utf8Value is the string value of the otherName SAN.
+                          The utf8Value accepts any valid UTF8 string to set as value for the otherName SAN.
+                        type: string
+                privateKey:
+                  description: |-
+                    Private key options. These include the key algorithm and size, the used
+                    encoding and the rotation policy.
+                  type: object
+                  properties:
+                    algorithm:
+                      description: |-
+                        Algorithm is the private key algorithm of the corresponding private key
+                        for this certificate.
+
+                        If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                        If `algorithm` is specified and `size` is not provided,
+                        key size of 2048 will be used for `RSA` key algorithm and
+                        key size of 256 will be used for `ECDSA` key algorithm.
+                        key size is ignored when using the `Ed25519` key algorithm.
+                      type: string
+                      enum:
+                        - RSA
+                        - ECDSA
+                        - Ed25519
+                    encoding:
+                      description: |-
+                        The private key cryptography standards (PKCS) encoding for this
+                        certificate's private key to be encoded in.
+
+                        If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                        and PKCS#8, respectively.
+                        Defaults to `PKCS1` if not specified.
+                      type: string
+                      enum:
+                        - PKCS1
+                        - PKCS8
+                    rotationPolicy:
+                      description: |-
+                        RotationPolicy controls how private keys should be regenerated when a
+                        re-issuance is being processed.
+
+                        If set to `Never`, a private key will only be generated if one does not
+                        already exist in the target `spec.secretName`. If one does exist but it
+                        does not have the correct algorithm or size, a warning will be raised
+                        to await user intervention.
+                        If set to `Always`, a private key matching the specified requirements
+                        will be generated whenever a re-issuance occurs.
+                        Default is `Never` for backward compatibility.
+                      type: string
+                      enum:
+                        - Never
+                        - Always
+                    size:
+                      description: |-
+                        Size is the key bit size of the corresponding private key for this certificate.
+
+                        If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                        and will default to `2048` if not specified.
+                        If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                        and will default to `256` if not specified.
+                        If `algorithm` is set to `Ed25519`, Size is ignored.
+                        No other values are allowed.
+                      type: integer
+                renewBefore:
+                  description: |-
+                    How long before the currently issued certificate's expiry cert-manager should
+                    renew the certificate. For example, if a certificate is valid for 60 minutes,
+                    and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                    50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                    the certificate is no longer valid).
+
+                    NOTE: The actual lifetime of the issued certificate is used to determine the
+                    renewal time. If an issuer returns a certificate with a different lifetime than
+                    the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                    If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                    Minimum accepted value is 5 minutes.
+                    Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                    Cannot be set if the `renewBeforePercentage` field is set.
+                  type: string
+                renewBeforePercentage:
+                  description: |-
+                    `renewBeforePercentage` is like `renewBefore`, except it is a relative percentage
+                    rather than an absolute duration. For example, if a certificate is valid for 60
+                    minutes, and  `renewBeforePercentage=25`, cert-manager will begin to attempt to
+                    renew the certificate 45 minutes after it was issued (i.e. when there are 15
+                    minutes (25%) remaining until the certificate is no longer valid).
+
+                    NOTE: The actual lifetime of the issued certificate is used to determine the
+                    renewal time. If an issuer returns a certificate with a different lifetime than
+                    the one requested, cert-manager will use the lifetime of the issued certificate.
+
+                    Value must be an integer in the range (0,100). The minimum effective
+                    `renewBefore` derived from the `renewBeforePercentage` and `duration` fields is 5
+                    minutes.
+                    Cannot be set if the `renewBefore` field is set.
+                  type: integer
+                  format: int32
+                revisionHistoryLimit:
+                  description: |-
+                    The maximum number of CertificateRequest revisions that are maintained in
+                    the Certificate's history. Each revision represents a single `CertificateRequest`
+                    created by this Certificate, either when it was created, renewed, or Spec
+                    was changed. Revisions will be removed by oldest first if the number of
+                    revisions exceeds this number.
+
+                    If set, revisionHistoryLimit must be a value of `1` or greater.
+                    If unset (`nil`), revisions will not be garbage collected.
+                    Default value is `nil`.
+                  type: integer
+                  format: int32
+                secretName:
+                  description: |-
+                    Name of the Secret resource that will be automatically created and
+                    managed by this Certificate resource. It will be populated with a
+                    private key and certificate, signed by the denoted issuer. The Secret
+                    resource lives in the same namespace as the Certificate resource.
+                  type: string
+                secretTemplate:
+                  description: |-
+                    Defines annotations and labels to be copied to the Certificate's Secret.
+                    Labels and annotations on the Secret will be changed as they appear on the
+                    SecretTemplate when added or removed. SecretTemplate annotations are added
+                    in conjunction with, and cannot overwrite, the base set of annotations
+                    cert-manager sets on the Certificate's Secret.
+                  type: object
+                  properties:
+                    annotations:
+                      description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    labels:
+                      description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                      type: object
+                      additionalProperties:
+                        type: string
+                subject:
+                  description: |-
+                    Requested set of X509 certificate subject attributes.
+                    More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+
+                    The common name attribute is specified separately in the `commonName` field.
+                    Cannot be set if the `literalSubject` field is set.
+                  type: object
+                  properties:
+                    countries:
+                      description: Countries to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    localities:
+                      description: Cities to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    organizationalUnits:
+                      description: Organizational Units to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    organizations:
+                      description: Organizations to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    postalCodes:
+                      description: Postal codes to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    provinces:
+                      description: State/Provinces to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    serialNumber:
+                      description: Serial number to be used on the Certificate.
+                      type: string
+                    streetAddresses:
+                      description: Street addresses to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                uris:
+                  description: Requested URI subject alternative names.
+                  type: array
+                  items:
+                    type: string
+                usages:
+                  description: |-
+                    Requested key usages and extended key usages.
+                    These usages are used to set the `usages` field on the created CertificateRequest
+                    resources. If `encodeUsagesInRequest` is unset or set to `true`, the usages
+                    will additionally be encoded in the `request` field which contains the CSR blob.
+
+                    If unset, defaults to `digital signature` and `key encipherment`.
+                  type: array
+                  items:
+                    description: |-
+                      KeyUsage specifies valid usage contexts for keys.
+                      See:
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+
+                      Valid KeyUsage values are as follows:
+                      "signing",
+                      "digital signature",
+                      "content commitment",
+                      "key encipherment",
+                      "key agreement",
+                      "data encipherment",
+                      "cert sign",
+                      "crl sign",
+                      "encipher only",
+                      "decipher only",
+                      "any",
+                      "server auth",
+                      "client auth",
+                      "code signing",
+                      "email protection",
+                      "s/mime",
+                      "ipsec end system",
+                      "ipsec tunnel",
+                      "ipsec user",
+                      "timestamping",
+                      "ocsp signing",
+                      "microsoft sgc",
+                      "netscape sgc"
+                    type: string
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+            status:
+              description: |-
+                Status of the Certificate.
+                This is set and managed automatically.
+                Read-only.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of certificates.
+                    Known condition types are `Ready` and `Issuing`.
+                  type: array
+                  items:
+                    description: CertificateCondition contains condition information for a Certificate.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Certificate.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`, `Issuing`).
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failedIssuanceAttempts:
+                  description: |-
+                    The number of continuous failed issuance attempts up till now. This
+                    field gets removed (if set) on a successful issuance and gets set to
+                    1 if unset and an issuance has failed. If an issuance has failed, the
+                    delay till the next issuance will be calculated using formula
+                    time.Hour * 2 ^ (failedIssuanceAttempts - 1).
+                  type: integer
+                lastFailureTime:
+                  description: |-
+                    LastFailureTime is set only if the latest issuance for this
+                    Certificate failed and contains the time of the failure. If an
+                    issuance has failed, the delay till the next issuance will be
+                    calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts -
+                    1). If the latest issuance has succeeded this field will be unset.
+                  type: string
+                  format: date-time
+                nextPrivateKeySecretName:
+                  description: |-
+                    The name of the Secret resource containing the private key to be used
+                    for the next certificate iteration.
+                    The keymanager controller will automatically set this field if the
+                    `Issuing` condition is set to `True`.
+                    It will automatically unset this field when the Issuing condition is
+                    not set or False.
+                  type: string
+                notAfter:
+                  description: |-
+                    The expiration time of the certificate stored in the secret named
+                    by this resource in `spec.secretName`.
+                  type: string
+                  format: date-time
+                notBefore:
+                  description: |-
+                    The time after which the certificate stored in the secret named
+                    by this resource in `spec.secretName` is valid.
+                  type: string
+                  format: date-time
+                renewalTime:
+                  description: |-
+                    RenewalTime is the time at which the certificate will be next
+                    renewed.
+                    If not set, no upcoming renewal is scheduled.
+                  type: string
+                  format: date-time
+                revision:
+                  description: |-
+                    The current 'revision' of the certificate as issued.
+
+                    When a CertificateRequest resource is created, it will have the
+                    `cert-manager.io/certificate-revision` set to one greater than the
+                    current value of this field.
+
+                    Upon issuance, this field will be set to the value of the annotation
+                    on the CertificateRequest resource used to issue the certificate.
+
+                    Persisting the value on the CertificateRequest resource allows the
+                    certificates controller to know whether a request is part of an old
+                    issuance or if it is part of the ongoing revision's issuance by
+                    checking if the revision value in the annotation is greater than this
+                    field.
+                  type: integer
+      served: true
+      storage: true
+
+# END crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.acme.cert-manager.io
+  # START annotations
+  annotations:
+    helm.sh/resource-policy: keep
+  # END annotations
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  group: acme.cert-manager.io
+  names:
+    kind: Challenge
+    listKind: ChallengeList
+    plural: challenges
+    singular: challenge
+    categories:
+      - cert-manager
+      - cert-manager-acme
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME server
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - authorizationURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
+              properties:
+                authorizationURL:
+                  description: |-
+                    The URL to the ACME Authorization resource that this
+                    challenge is a part of.
+                  type: string
+                dnsName:
+                  description: |-
+                    dnsName is the identifier that this challenge is for, e.g. example.com.
+                    If the requested DNSName is a 'wildcard', this field MUST be set to the
+                    non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.
+                  type: string
+                issuerRef:
+                  description: |-
+                    References a properly configured ACME-type Issuer which should
+                    be used to create this Challenge.
+                    If the Issuer does not exist, processing will be retried.
+                    If the Issuer is not an 'ACME' Issuer, an error will be returned and the
+                    Challenge will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                key:
+                  description: |-
+                    The ACME challenge key for this challenge
+                    For HTTP01 challenges, this is the value that must be responded with to
+                    complete the HTTP01 challenge in the format:
+                    `<private key JWK thumbprint>.<key from acme server for challenge>`.
+                    For DNS01 challenges, this is the base64 encoded SHA256 sum of the
+                    `<private key JWK thumbprint>.<key from acme server for challenge>`
+                    text that must be set as the TXT record content.
+                  type: string
+                solver:
+                  description: |-
+                    Contains the domain solving configuration that should be used to
+                    solve this challenge resource.
+                  type: object
+                  properties:
+                    dns01:
+                      description: |-
+                        Configures cert-manager to attempt to complete authorizations by
+                        performing the DNS01 challenge flow.
+                      type: object
+                      properties:
+                        acmeDNS:
+                          description: |-
+                            Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
+                            DNS01 challenge records.
+                          type: object
+                          required:
+                            - accountSecretRef
+                            - host
+                          properties:
+                            accountSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            host:
+                              type: string
+                        akamai:
+                          description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          properties:
+                            accessTokenSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            clientSecretSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            clientTokenSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            serviceConsumerDomain:
+                              type: string
+                        azureDNS:
+                          description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          properties:
+                            clientID:
+                              description: |-
+                                Auth: Azure Service Principal:
+                                The ClientID of the Azure Service Principal used to authenticate with Azure DNS.
+                                If set, ClientSecret and TenantID must also be set.
+                              type: string
+                            clientSecretSecretRef:
+                              description: |-
+                                Auth: Azure Service Principal:
+                                A reference to a Secret containing the password associated with the Service Principal.
+                                If set, ClientID and TenantID must also be set.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            environment:
+                              description: name of the Azure environment (default AzurePublicCloud)
+                              type: string
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                            hostedZoneName:
+                              description: name of the DNS zone that should be used
+                              type: string
+                            managedIdentity:
+                              description: |-
+                                Auth: Azure Workload Identity or Azure Managed Service Identity:
+                                Settings to enable Azure Workload Identity or Azure Managed Service Identity
+                                If set, ClientID, ClientSecret and TenantID must not be set.
+                              type: object
+                              properties:
+                                clientID:
+                                  description: client ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
+                                resourceID:
+                                  description: |-
+                                    resource ID of the managed identity, can not be used at the same time as clientID
+                                    Cannot be used for Azure Managed Service Identity
+                                  type: string
+                                tenantID:
+                                  description: tenant ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
+                            resourceGroupName:
+                              description: resource group the DNS zone is located in
+                              type: string
+                            subscriptionID:
+                              description: ID of the Azure subscription
+                              type: string
+                            tenantID:
+                              description: |-
+                                Auth: Azure Service Principal:
+                                The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
+                                If set, ClientID and ClientSecret must also be set.
+                              type: string
+                        cloudDNS:
+                          description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - project
+                          properties:
+                            hostedZoneName:
+                              description: |-
+                                HostedZoneName is an optional field that tells cert-manager in which
+                                Cloud DNS zone the challenge record has to be created.
+                                If left empty cert-manager will automatically choose a zone.
+                              type: string
+                            project:
+                              type: string
+                            serviceAccountSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                        cloudflare:
+                          description: Use the Cloudflare API to manage DNS01 challenge records.
+                          type: object
+                          properties:
+                            apiKeySecretRef:
+                              description: |-
+                                API key to use to authenticate with Cloudflare.
+                                Note: using an API token to authenticate is now the recommended method
+                                as it allows greater control of permissions.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            apiTokenSecretRef:
+                              description: API token used to authenticate with Cloudflare.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            email:
+                              description: Email of the account, only required when using API key based authentication.
+                              type: string
+                        cnameStrategy:
+                          description: |-
+                            CNAMEStrategy configures how the DNS01 provider should handle CNAME
+                            records when found in DNS zones.
+                          type: string
+                          enum:
+                            - None
+                            - Follow
+                        digitalocean:
+                          description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - tokenSecretRef
+                          properties:
+                            tokenSecretRef:
+                              description: |-
+                                A reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                        rfc2136:
+                          description: |-
+                            Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                            to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - nameserver
+                          properties:
+                            nameserver:
+                              description: |-
+                                The IP address or hostname of an authoritative DNS server supporting
+                                RFC2136 in the form host:port. If the host is an IPv6 address it must be
+                                enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                This field is required.
+                              type: string
+                            tsigAlgorithm:
+                              description: |-
+                                The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
+                                when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
+                                Supported values are (case-insensitive): ``HMACMD5`` (default),
+                                ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
+                              type: string
+                            tsigKeyName:
+                              description: |-
+                                The TSIG Key name configured in the DNS.
+                                If ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: |-
+                                The name of the secret containing the TSIG value.
+                                If ``tsigKeyName`` is defined, this field is required.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                        route53:
+                          description: Use the AWS Route53 API to manage DNS01 challenge records.
+                          type: object
+                          properties:
+                            accessKeyID:
+                              description: |-
+                                The AccessKeyID is used for authentication.
+                                Cannot be set when SecretAccessKeyID is set.
+                                If neither the Access Key nor Key ID are set, we fall-back to using env
+                                vars, shared credentials file or AWS Instance metadata,
+                                see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: string
+                            accessKeyIDSecretRef:
+                              description: |-
+                                The SecretAccessKey is used for authentication. If set, pull the AWS
+                                access key ID from a key within a Kubernetes Secret.
+                                Cannot be set when AccessKeyID is set.
+                                If neither the Access Key nor Key ID are set, we fall-back to using env
+                                vars, shared credentials file or AWS Instance metadata,
+                                see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            auth:
+                              description: Auth configures how cert-manager authenticates.
+                              type: object
+                              required:
+                                - kubernetes
+                              properties:
+                                kubernetes:
+                                  description: |-
+                                    Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
+                                    by passing a bound ServiceAccount token.
+                                  type: object
+                                  required:
+                                    - serviceAccountRef
+                                  properties:
+                                    serviceAccountRef:
+                                      description: |-
+                                        A reference to a service account that will be used to request a bound
+                                        token (also known as "projected token"). To use this field, you must
+                                        configure an RBAC rule to let cert-manager request a token.
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            TokenAudiences is an optional list of audiences to include in the
+                                            token passed to AWS. The default token consisting of the issuer's namespace
+                                            and name is always included.
+                                            If unset the audience defaults to `sts.amazonaws.com`.
+                                          type: array
+                                          items:
+                                            type: string
+                                        name:
+                                          description: Name of the ServiceAccount used to request a token.
+                                          type: string
+                            hostedZoneID:
+                              description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
+                              type: string
+                            region:
+                              description: |-
+                                Override the AWS region.
+
+                                Route53 is a global service and does not have regional endpoints but the
+                                region specified here (or via environment variables) is used as a hint to
+                                help compute the correct AWS credential scope and partition when it
+                                connects to Route53. See:
+                                - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                If you omit this region field, cert-manager will use the region from
+                                AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                in the cert-manager controller Pod.
+
+                                The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                In this case this `region` field value is ignored.
+
+                                The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+                                In this case this `region` field value is ignored.
+                              type: string
+                            role:
+                              description: |-
+                                Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: |-
+                                The SecretAccessKey is used for authentication.
+                                If neither the Access Key nor Key ID are set, we fall-back to using env
+                                vars, shared credentials file or AWS Instance metadata,
+                                see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                        webhook:
+                          description: |-
+                            Configure an external webhook based DNS01 challenge solver to manage
+                            DNS01 challenge records.
+                          type: object
+                          required:
+                            - groupName
+                            - solverName
+                          properties:
+                            config:
+                              description: |-
+                                Additional configuration that should be passed to the webhook apiserver
+                                when challenges are processed.
+                                This can contain arbitrary JSON data.
+                                Secret values should not be specified in this stanza.
+                                If secret values are needed (e.g. credentials for a DNS service), you
+                                should use a SecretKeySelector to reference a Secret resource.
+                                For details on the schema of this field, consult the webhook provider
+                                implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: |-
+                                The API group name that should be used when POSTing ChallengePayload
+                                resources to the webhook apiserver.
+                                This should be the same as the GroupName specified in the webhook
+                                provider implementation.
+                              type: string
+                            solverName:
+                              description: |-
+                                The name of the solver to use, as defined in the webhook provider
+                                implementation.
+                                This will typically be the name of the provider, e.g. 'cloudflare'.
+                              type: string
+                    http01:
+                      description: |-
+                        Configures cert-manager to attempt to complete authorizations by
+                        performing the HTTP01 challenge flow.
+                        It is not possible to obtain certificates for wildcard domain names
+                        (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                      type: object
+                      properties:
+                        gatewayHTTPRoute:
+                          description: |-
+                            The Gateway API is a sig-network community API that models service networking
+                            in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
+                            create HTTPRoutes with the specified labels in the same namespace as the challenge.
+                            This solver is experimental, and fields / behaviour may change in the future.
+                          type: object
+                          properties:
+                            labels:
+                              description: |-
+                                Custom labels that will be applied to HTTPRoutes created by cert-manager
+                                while solving HTTP-01 challenges.
+                              type: object
+                              additionalProperties:
+                                type: string
+                            parentRefs:
+                              description: |-
+                                When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+                                cert-manager needs to know which parentRefs should be used when creating
+                                the HTTPRoute. Usually, the parentRef references a Gateway. See:
+                                https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+                              type: array
+                              items:
+                                description: |-
+                                  ParentReference identifies an API object (usually a Gateway) that can be considered
+                                  a parent of this resource (usually a route). There are two kinds of parent resources
+                                  with "Core" support:
+
+                                  * Gateway (Gateway conformance profile)
+                                  * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                  This API may be extended in the future to support additional kinds of parent
+                                  resources.
+
+                                  The API object must be valid in the cluster; the Group and Kind must
+                                  be registered in the cluster for this reference to be valid.
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  group:
+                                    description: |-
+                                      Group is the group of the referent.
+                                      When unspecified, "gateway.networking.k8s.io" is inferred.
+                                      To set the core API group (such as for a "Service" kind referent),
+                                      Group must be explicitly set to "" (empty string).
+
+                                      Support: Core
+                                    type: string
+                                    default: gateway.networking.k8s.io
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  kind:
+                                    description: |-
+                                      Kind is kind of the referent.
+
+                                      There are two kinds of parent resources with "Core" support:
+
+                                      * Gateway (Gateway conformance profile)
+                                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                      Support for other resources is Implementation-Specific.
+                                    type: string
+                                    default: Gateway
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  name:
+                                    description: |-
+                                      Name is the name of the referent.
+
+                                      Support: Core
+                                    type: string
+                                    maxLength: 253
+                                    minLength: 1
+                                  namespace:
+                                    description: |-
+                                      Namespace is the namespace of the referent. When unspecified, this refers
+                                      to the local namespace of the Route.
+
+                                      Note that there are specific rules for ParentRefs which cross namespace
+                                      boundaries. Cross-namespace references are only valid if they are explicitly
+                                      allowed by something in the namespace they are referring to. For example:
+                                      Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                                      generic way to enable any other kind of cross-namespace reference.
+
+                                      <gateway:experimental:description>
+                                      ParentRefs from a Route to a Service in the same namespace are "producer"
+                                      routes, which apply default routing rules to inbound connections from
+                                      any namespace to the Service.
+
+                                      ParentRefs from a Route to a Service in a different namespace are
+                                      "consumer" routes, and these routing rules are only applied to outbound
+                                      connections originating from the same namespace as the Route, for which
+                                      the intended destination of the connections are a Service targeted as a
+                                      ParentRef of the Route.
+                                      </gateway:experimental:description>
+
+                                      Support: Core
+                                    type: string
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  port:
+                                    description: |-
+                                      Port is the network port this Route targets. It can be interpreted
+                                      differently based on the type of parent resource.
+
+                                      When the parent resource is a Gateway, this targets all listeners
+                                      listening on the specified port that also support this kind of Route(and
+                                      select this Route). It's not recommended to set `Port` unless the
+                                      networking behaviors specified in a Route must apply to a specific port
+                                      as opposed to a listener(s) whose port(s) may be changed. When both Port
+                                      and SectionName are specified, the name and port of the selected listener
+                                      must match both specified values.
+
+                                      <gateway:experimental:description>
+                                      When the parent resource is a Service, this targets a specific port in the
+                                      Service spec. When both Port (experimental) and SectionName are specified,
+                                      the name and port of the selected port must match both specified values.
+                                      </gateway:experimental:description>
+
+                                      Implementations MAY choose to support other parent resources.
+                                      Implementations supporting other types of parent resources MUST clearly
+                                      document how/if Port is interpreted.
+
+                                      For the purpose of status, an attachment is considered successful as
+                                      long as the parent resource accepts it partially. For example, Gateway
+                                      listeners can restrict which Routes can attach to them by Route kind,
+                                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                                      from the referencing Route, the Route MUST be considered successfully
+                                      attached. If no Gateway listeners accept attachment from this Route,
+                                      the Route MUST be considered detached from the Gateway.
+
+                                      Support: Extended
+                                    type: integer
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                  sectionName:
+                                    description: |-
+                                      SectionName is the name of a section within the target resource. In the
+                                      following resources, SectionName is interpreted as the following:
+
+                                      * Gateway: Listener name. When both Port (experimental) and SectionName
+                                      are specified, the name and port of the selected listener must match
+                                      both specified values.
+                                      * Service: Port name. When both Port (experimental) and SectionName
+                                      are specified, the name and port of the selected listener must match
+                                      both specified values.
+
+                                      Implementations MAY choose to support attaching Routes to other resources.
+                                      If that is the case, they MUST clearly document how SectionName is
+                                      interpreted.
+
+                                      When unspecified (empty string), this will reference the entire resource.
+                                      For the purpose of status, an attachment is considered successful if at
+                                      least one section in the parent resource accepts it. For example, Gateway
+                                      listeners can restrict which Routes can attach to them by Route kind,
+                                      namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                                      the referencing Route, the Route MUST be considered successfully
+                                      attached. If no Gateway listeners accept attachment from this Route, the
+                                      Route MUST be considered detached from the Gateway.
+
+                                      Support: Core
+                                    type: string
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            podTemplate:
+                              description: |-
+                                Optional pod template used to configure the ACME challenge solver pods
+                                used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: |-
+                                    ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                    Only the 'labels' and 'annotations' fields may be set.
+                                    If labels or annotations overlap with in-built values, the values here
+                                    will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: |-
+                                    PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                    Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                    All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      type: object
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: |-
+                                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                type: object
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to an update), the system
+                                                may or may not try to eventually evict the pod from its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: |-
+                                                      A null or empty node selector term matches no objects. The requirements of
+                                                      them are ANDed.
+                                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                                  x-kubernetes-list-type: atomic
+                                              x-kubernetes-map-type: atomic
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                                  x-kubernetes-list-type: atomic
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                                  x-kubernetes-list-type: atomic
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                              x-kubernetes-list-type: atomic
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the anti-affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                                  x-kubernetes-list-type: atomic
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                                  x-kubernetes-list-type: atomic
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the anti-affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the anti-affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                              x-kubernetes-list-type: atomic
+                                    imagePullSecrets:
+                                      description: If specified, the pod's imagePullSecrets
+                                      type: array
+                                      items:
+                                        description: |-
+                                          LocalObjectReference contains enough information to let you locate the
+                                          referenced object inside the same namespace.
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                            default: ""
+                                        x-kubernetes-map-type: atomic
+                                    nodeSelector:
+                                      description: |-
+                                        NodeSelector is a selector which must be true for the pod to fit on a node.
+                                        Selector which must match a node's labels for the pod to be scheduled on that node.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    securityContext:
+                                      description: If specified, the pod's security context
+                                      type: object
+                                      properties:
+                                        fsGroup:
+                                          description: |-
+                                            A special supplemental group that applies to all containers in a pod.
+                                            Some volume types allow the Kubelet to change the ownership of that volume
+                                            to be owned by the pod:
+
+                                            1. The owning GID will be the FSGroup
+                                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                            3. The permission bits are OR'd with rw-rw----
+
+                                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: integer
+                                          format: int64
+                                        fsGroupChangePolicy:
+                                          description: |-
+                                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                            before being exposed inside Pod. This field will only apply to
+                                            volume types which support fsGroup based ownership(and permissions).
+                                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                                            and emptydir.
+                                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: integer
+                                          format: int64
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: integer
+                                          format: int64
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to all containers.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in SecurityContext.  If set in
+                                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                            takes precedence for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: object
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user label that applies to the container.
+                                              type: string
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by the containers in this pod.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: object
+                                          required:
+                                            - type
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                        supplementalGroups:
+                                          description: |-
+                                            A list of groups applied to the first process run in each container, in addition
+                                            to the container's primary GID, the fsGroup (if specified), and group memberships
+                                            defined in the container image for the uid of the container process. If unspecified,
+                                            no additional groups are added to any container. Note that group memberships
+                                            defined in the container image for the uid of the container process are still effective,
+                                            even if they are not included in this list.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: array
+                                          items:
+                                            type: integer
+                                            format: int64
+                                        sysctls:
+                                          description: |-
+                                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                            sysctls (by the container runtime) might fail to launch.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: array
+                                          items:
+                                            description: Sysctl defines a kernel parameter to be set
+                                            type: object
+                                            required:
+                                              - name
+                                              - value
+                                            properties:
+                                              name:
+                                                description: Name of a property to set
+                                                type: string
+                                              value:
+                                                description: Value of a property to set
+                                                type: string
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: |-
+                                          The pod this Toleration is attached to tolerates any taint that matches
+                                          the triple <key,value,effect> using the matching operator <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: |-
+                                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: |-
+                                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Operator represents a key's relationship to the value.
+                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Exists is equivalent to wildcard for value, so that a pod can
+                                              tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: |-
+                                              TolerationSeconds represents the period of time the toleration (which must be
+                                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                              negative values will be treated as 0 (evict immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: |-
+                                              Value is the taint value the toleration matches to.
+                                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                            serviceType:
+                              description: |-
+                                Optional service type for Kubernetes solver service. Supported values
+                                are NodePort or ClusterIP. If unset, defaults to NodePort.
+                              type: string
+                        ingress:
+                          description: |-
+                            The ingress based HTTP01 challenge solver will solve challenges by
+                            creating or modifying Ingress resources in order to route requests for
+                            '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
+                            provisioned by cert-manager for each Challenge to be completed.
+                          type: object
+                          properties:
+                            class:
+                              description: |-
+                                This field configures the annotation `kubernetes.io/ingress.class` when
+                                creating Ingress resources to solve ACME challenges that use this
+                                challenge solver. Only one of `class`, `name` or `ingressClassName` may
+                                be specified.
+                              type: string
+                            ingressClassName:
+                              description: |-
+                                This field configures the field `ingressClassName` on the created Ingress
+                                resources used to solve ACME challenges that use this challenge solver.
+                                This is the recommended way of configuring the ingress class. Only one of
+                                `class`, `name` or `ingressClassName` may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: |-
+                                Optional ingress template used to configure the ACME challenge solver
+                                ingress used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: |-
+                                    ObjectMeta overrides for the ingress used to solve HTTP01 challenges.
+                                    Only the 'labels' and 'annotations' fields may be set.
+                                    If labels or annotations overlap with in-built values, the values here
+                                    will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                            name:
+                              description: |-
+                                The name of the ingress resource that should have ACME challenge solving
+                                routes inserted into it in order to solve HTTP01 challenges.
+                                This is typically used in conjunction with ingress controllers like
+                                ingress-gce, which maintains a 1:1 mapping between external IPs and
+                                ingress resources. Only one of `class`, `name` or `ingressClassName` may
+                                be specified.
+                              type: string
+                            podTemplate:
+                              description: |-
+                                Optional pod template used to configure the ACME challenge solver pods
+                                used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: |-
+                                    ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                    Only the 'labels' and 'annotations' fields may be set.
+                                    If labels or annotations overlap with in-built values, the values here
+                                    will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: |-
+                                    PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                    Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                    All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      type: object
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: |-
+                                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                type: object
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to an update), the system
+                                                may or may not try to eventually evict the pod from its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: |-
+                                                      A null or empty node selector term matches no objects. The requirements of
+                                                      them are ANDed.
+                                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                                  x-kubernetes-list-type: atomic
+                                              x-kubernetes-map-type: atomic
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                                  x-kubernetes-list-type: atomic
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                                  x-kubernetes-list-type: atomic
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                              x-kubernetes-list-type: atomic
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the anti-affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                                  x-kubernetes-list-type: atomic
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                                  x-kubernetes-list-type: atomic
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                              x-kubernetes-list-type: atomic
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the anti-affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the anti-affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                              x-kubernetes-list-type: atomic
+                                    imagePullSecrets:
+                                      description: If specified, the pod's imagePullSecrets
+                                      type: array
+                                      items:
+                                        description: |-
+                                          LocalObjectReference contains enough information to let you locate the
+                                          referenced object inside the same namespace.
+                                        type: object
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                            default: ""
+                                        x-kubernetes-map-type: atomic
+                                    nodeSelector:
+                                      description: |-
+                                        NodeSelector is a selector which must be true for the pod to fit on a node.
+                                        Selector which must match a node's labels for the pod to be scheduled on that node.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    securityContext:
+                                      description: If specified, the pod's security context
+                                      type: object
+                                      properties:
+                                        fsGroup:
+                                          description: |-
+                                            A special supplemental group that applies to all containers in a pod.
+                                            Some volume types allow the Kubelet to change the ownership of that volume
+                                            to be owned by the pod:
+
+                                            1. The owning GID will be the FSGroup
+                                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                            3. The permission bits are OR'd with rw-rw----
+
+                                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: integer
+                                          format: int64
+                                        fsGroupChangePolicy:
+                                          description: |-
+                                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                            before being exposed inside Pod. This field will only apply to
+                                            volume types which support fsGroup based ownership(and permissions).
+                                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                                            and emptydir.
+                                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: integer
+                                          format: int64
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: integer
+                                          format: int64
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to all containers.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in SecurityContext.  If set in
+                                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                            takes precedence for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: object
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user label that applies to the container.
+                                              type: string
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by the containers in this pod.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: object
+                                          required:
+                                            - type
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                        supplementalGroups:
+                                          description: |-
+                                            A list of groups applied to the first process run in each container, in addition
+                                            to the container's primary GID, the fsGroup (if specified), and group memberships
+                                            defined in the container image for the uid of the container process. If unspecified,
+                                            no additional groups are added to any container. Note that group memberships
+                                            defined in the container image for the uid of the container process are still effective,
+                                            even if they are not included in this list.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: array
+                                          items:
+                                            type: integer
+                                            format: int64
+                                        sysctls:
+                                          description: |-
+                                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                            sysctls (by the container runtime) might fail to launch.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: array
+                                          items:
+                                            description: Sysctl defines a kernel parameter to be set
+                                            type: object
+                                            required:
+                                              - name
+                                              - value
+                                            properties:
+                                              name:
+                                                description: Name of a property to set
+                                                type: string
+                                              value:
+                                                description: Value of a property to set
+                                                type: string
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: |-
+                                          The pod this Toleration is attached to tolerates any taint that matches
+                                          the triple <key,value,effect> using the matching operator <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: |-
+                                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: |-
+                                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Operator represents a key's relationship to the value.
+                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Exists is equivalent to wildcard for value, so that a pod can
+                                              tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: |-
+                                              TolerationSeconds represents the period of time the toleration (which must be
+                                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                              negative values will be treated as 0 (evict immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: |-
+                                              Value is the taint value the toleration matches to.
+                                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                            serviceType:
+                              description: |-
+                                Optional service type for Kubernetes solver service. Supported values
+                                are NodePort or ClusterIP. If unset, defaults to NodePort.
+                              type: string
+                    selector:
+                      description: |-
+                        Selector selects a set of DNSNames on the Certificate resource that
+                        should be solved using this challenge solver.
+                        If not specified, the solver will be treated as the 'default' solver
+                        with the lowest priority, i.e. if any other solver has a more specific
+                        match, it will be used instead.
+                      type: object
+                      properties:
+                        dnsNames:
+                          description: |-
+                            List of DNSNames that this solver will be used to solve.
+                            If specified and a match is found, a dnsNames selector will take
+                            precedence over a dnsZones selector.
+                            If multiple solvers match with the same dnsNames value, the solver
+                            with the most matching labels in matchLabels will be selected.
+                            If neither has more matches, the solver defined earlier in the list
+                            will be selected.
+                          type: array
+                          items:
+                            type: string
+                        dnsZones:
+                          description: |-
+                            List of DNSZones that this solver will be used to solve.
+                            The most specific DNS zone match specified here will take precedence
+                            over other DNS zone matches, so a solver specifying sys.example.com
+                            will be selected over one specifying example.com for the domain
+                            www.sys.example.com.
+                            If multiple solvers match with the same dnsZones value, the solver
+                            with the most matching labels in matchLabels will be selected.
+                            If neither has more matches, the solver defined earlier in the list
+                            will be selected.
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          description: |-
+                            A label selector that is used to refine the set of certificate's that
+                            this challenge solver will apply to.
+                          type: object
+                          additionalProperties:
+                            type: string
+                token:
+                  description: |-
+                    The ACME challenge token for this challenge.
+                    This is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: |-
+                    The type of ACME challenge this resource represents.
+                    One of "HTTP-01" or "DNS-01".
+                  type: string
+                  enum:
+                    - HTTP-01
+                    - DNS-01
+                url:
+                  description: |-
+                    The URL of the ACME Challenge resource for this challenge.
+                    This can be used to lookup details about the status of this challenge.
+                  type: string
+                wildcard:
+                  description: |-
+                    wildcard will be true if this challenge is for a wildcard identifier,
+                    for example '*.example.com'.
+                  type: boolean
+            status:
+              type: object
+              properties:
+                presented:
+                  description: |-
+                    presented will be set to true if the challenge values for this challenge
+                    are currently 'presented'.
+                    This *does not* imply the self check is passing. Only that the values
+                    have been 'submitted' for the appropriate challenge mechanism (i.e. the
+                    DNS01 TXT record has been presented, or the HTTP01 configuration has been
+                    configured).
+                  type: boolean
+                processing:
+                  description: |-
+                    Used to denote whether this challenge should be processed or not.
+                    This field will only be set to true by the 'scheduling' component.
+                    It will only be set to false by the 'challenges' controller, after the
+                    challenge has reached a final state or timed out.
+                    If this field is set to false, the challenge controller will not take
+                    any more action.
+                  type: boolean
+                reason:
+                  description: |-
+                    Contains human readable information on why the Challenge is in the
+                    current state.
+                  type: string
+                state:
+                  description: |-
+                    Contains the current 'state' of the challenge.
+                    If not set, the state of the challenge is unknown.
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+      served: true
+      storage: true
+      subresources:
+        status: {}
+
+# END crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.cert-manager.io
+  # START annotations
+  annotations:
+    helm.sh/resource-policy: keep
+  # END annotations
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  group: cert-manager.io
+  names:
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    singular: clusterissuer
+    categories:
+      - cert-manager
+  scope: Cluster
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: |-
+            A ClusterIssuer represents a certificate issuing authority which can be
+            referenced as part of `issuerRef` fields.
+            It is similar to an Issuer, however it is cluster-scoped and therefore can
+            be referenced by resources that exist in *any* namespace, not just the same
+            namespace as the referent.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: |-
+                    ACME configures this issuer to communicate with a RFC8555 (ACME) server
+                    to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    caBundle:
+                      description: |-
+                        Base64-encoded bundle of PEM CAs which can be used to validate the certificate
+                        chain presented by the ACME server.
+                        Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various
+                        kinds of security vulnerabilities.
+                        If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                        the container is used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    disableAccountKeyGeneration:
+                      description: |-
+                        Enables or disables generating a new ACME account key.
+                        If true, the Issuer resource will *not* request a new account but will expect
+                        the account key to be supplied via an existing secret.
+                        If false, the cert-manager system will generate a new ACME account key
+                        for the Issuer.
+                        Defaults to false.
+                      type: boolean
+                    email:
+                      description: |-
+                        Email is the email address to be associated with the ACME account.
+                        This field is optional, but it is strongly recommended to be set.
+                        It will be used to contact you in case of issues with your account or
+                        certificates, including expiry notification emails.
+                        This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: |-
+                        Enables requesting a Not After date on certificates that matches the
+                        duration of the certificate. This is not supported by all ACME servers
+                        like Let's Encrypt. If set to true when the ACME server does not support
+                        it, it will create an error on the Order.
+                        Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: |-
+                        ExternalAccountBinding is a reference to a CA external account of the ACME
+                        server.
+                        If set, upon registration cert-manager will attempt to associate the given
+                        external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: |-
+                            Deprecated: keyAlgorithm field exists for historical compatibility
+                            reasons and should not be used. The algorithm is now hardcoded to HS256
+                            in golang/x/crypto/acme.
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: |-
+                            keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
+                            Secret which holds the symmetric MAC key of the External Account Binding.
+                            The `key` is the index string that is paired with the key data in the
+                            Secret and should not be confused with the key data itself, or indeed with
+                            the External Account Binding keyID above.
+                            The secret key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                    preferredChain:
+                      description: |-
+                        PreferredChain is the chain to use if the ACME server outputs multiple.
+                        PreferredChain is no guarantee that this one gets delivered by the ACME
+                        endpoint.
+                        For example, for Let's Encrypt's DST crosssign you would use:
+                        "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+                        This value picks the first certificate bundle in the combined set of
+                        ACME default and alternative chains that has a root-most certificate with
+                        this value as its issuer's commonname.
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: |-
+                        PrivateKey is the name of a Kubernetes Secret resource that will be used to
+                        store the automatically generated ACME account private key.
+                        Optionally, a `key` may be specified to select a specific entry within
+                        the named Secret resource.
+                        If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                    server:
+                      description: |-
+                        Server is the URL used to access the ACME server's 'directory' endpoint.
+                        For example, for Let's Encrypt's staging endpoint, you would use:
+                        "https://acme-staging-v02.api.letsencrypt.org/directory".
+                        Only ACME v2 endpoints (i.e. RFC 8555) are supported.
+                      type: string
+                    skipTLSVerify:
+                      description: |-
+                        INSECURE: Enables or disables validation of the ACME server TLS certificate.
+                        If true, requests to the ACME server will not have the TLS certificate chain
+                        validated.
+                        Mutually exclusive with CABundle; prefer using CABundle to prevent various
+                        kinds of security vulnerabilities.
+                        Only enable this option in development environments.
+                        If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                        the container is used to validate the TLS connection.
+                        Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: |-
+                        Solvers is a list of challenge solvers that will be used to solve
+                        ACME challenges for the matching domains.
+                        Solver configurations must be provided in order to obtain certificates
+                        from an ACME server.
+                        For more information, see: https://cert-manager.io/docs/configuration/acme/
+                      type: array
+                      items:
+                        description: |-
+                          An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of.
+                          A selector may be provided to use different solving strategies for different DNS names.
+                          Only one of HTTP01 or DNS01 must be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: |-
+                              Configures cert-manager to attempt to complete authorizations by
+                              performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmeDNS:
+                                description: |-
+                                  Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
+                                  DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      The ClientID of the Azure Service Principal used to authenticate with Azure DNS.
+                                      If set, ClientSecret and TenantID must also be set.
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      A reference to a Secret containing the password associated with the Service Principal.
+                                      If set, ClientID and TenantID must also be set.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    description: name of the DNS zone that should be used
+                                    type: string
+                                  managedIdentity:
+                                    description: |-
+                                      Auth: Azure Workload Identity or Azure Managed Service Identity:
+                                      Settings to enable Azure Workload Identity or Azure Managed Service Identity
+                                      If set, ClientID, ClientSecret and TenantID must not be set.
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: |-
+                                          resource ID of the managed identity, can not be used at the same time as clientID
+                                          Cannot be used for Azure Managed Service Identity
+                                        type: string
+                                      tenantID:
+                                        description: tenant ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                  resourceGroupName:
+                                    description: resource group the DNS zone is located in
+                                    type: string
+                                  subscriptionID:
+                                    description: ID of the Azure subscription
+                                    type: string
+                                  tenantID:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
+                                      If set, ClientID and ClientSecret must also be set.
+                                    type: string
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: |-
+                                      HostedZoneName is an optional field that tells cert-manager in which
+                                      Cloud DNS zone the challenge record has to be created.
+                                      If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: |-
+                                      API key to use to authenticate with Cloudflare.
+                                      Note: using an API token to authenticate is now the recommended method
+                                      as it allows greater control of permissions.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: |-
+                                  CNAMEStrategy configures how the DNS01 provider should handle CNAME
+                                  records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                              rfc2136:
+                                description: |-
+                                  Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                  to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: |-
+                                      The IP address or hostname of an authoritative DNS server supporting
+                                      RFC2136 in the form host:port. If the host is an IPv6 address it must be
+                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: |-
+                                      The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
+                                      when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
+                                      Supported values are (case-insensitive): ``HMACMD5`` (default),
+                                      ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
+                                    type: string
+                                  tsigKeyName:
+                                    description: |-
+                                      The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: |-
+                                      The name of the secret containing the TSIG value.
+                                      If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  accessKeyID:
+                                    description: |-
+                                      The AccessKeyID is used for authentication.
+                                      Cannot be set when SecretAccessKeyID is set.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: string
+                                  accessKeyIDSecretRef:
+                                    description: |-
+                                      The SecretAccessKey is used for authentication. If set, pull the AWS
+                                      access key ID from a key within a Kubernetes Secret.
+                                      Cannot be set when AccessKeyID is set.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  auth:
+                                    description: Auth configures how cert-manager authenticates.
+                                    type: object
+                                    required:
+                                      - kubernetes
+                                    properties:
+                                      kubernetes:
+                                        description: |-
+                                          Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
+                                          by passing a bound ServiceAccount token.
+                                        type: object
+                                        required:
+                                          - serviceAccountRef
+                                        properties:
+                                          serviceAccountRef:
+                                            description: |-
+                                              A reference to a service account that will be used to request a bound
+                                              token (also known as "projected token"). To use this field, you must
+                                              configure an RBAC rule to let cert-manager request a token.
+                                            type: object
+                                            required:
+                                              - name
+                                            properties:
+                                              audiences:
+                                                description: |-
+                                                  TokenAudiences is an optional list of audiences to include in the
+                                                  token passed to AWS. The default token consisting of the issuer's namespace
+                                                  and name is always included.
+                                                  If unset the audience defaults to `sts.amazonaws.com`.
+                                                type: array
+                                                items:
+                                                  type: string
+                                              name:
+                                                description: Name of the ServiceAccount used to request a token.
+                                                type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: |-
+                                      Override the AWS region.
+
+                                      Route53 is a global service and does not have regional endpoints but the
+                                      region specified here (or via environment variables) is used as a hint to
+                                      help compute the correct AWS credential scope and partition when it
+                                      connects to Route53. See:
+                                      - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                      - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                      If you omit this region field, cert-manager will use the region from
+                                      AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                      in the cert-manager controller Pod.
+
+                                      The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                      In this case this `region` field value is ignored.
+
+                                      The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+                                      In this case this `region` field value is ignored.
+                                    type: string
+                                  role:
+                                    description: |-
+                                      Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                      or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: |-
+                                      The SecretAccessKey is used for authentication.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                              webhook:
+                                description: |-
+                                  Configure an external webhook based DNS01 challenge solver to manage
+                                  DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: |-
+                                      Additional configuration that should be passed to the webhook apiserver
+                                      when challenges are processed.
+                                      This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for a DNS service), you
+                                      should use a SecretKeySelector to reference a Secret resource.
+                                      For details on the schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: |-
+                                      The API group name that should be used when POSTing ChallengePayload
+                                      resources to the webhook apiserver.
+                                      This should be the same as the GroupName specified in the webhook
+                                      provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: |-
+                                      The name of the solver to use, as defined in the webhook provider
+                                      implementation.
+                                      This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: |-
+                              Configures cert-manager to attempt to complete authorizations by
+                              performing the HTTP01 challenge flow.
+                              It is not possible to obtain certificates for wildcard domain names
+                              (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: |-
+                                  The Gateway API is a sig-network community API that models service networking
+                                  in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
+                                  create HTTPRoutes with the specified labels in the same namespace as the challenge.
+                                  This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: |-
+                                      Custom labels that will be applied to HTTPRoutes created by cert-manager
+                                      while solving HTTP-01 challenges.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  parentRefs:
+                                    description: |-
+                                      When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+                                      cert-manager needs to know which parentRefs should be used when creating
+                                      the HTTPRoute. Usually, the parentRef references a Gateway. See:
+                                      https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+                                    type: array
+                                    items:
+                                      description: |-
+                                        ParentReference identifies an API object (usually a Gateway) that can be considered
+                                        a parent of this resource (usually a route). There are two kinds of parent resources
+                                        with "Core" support:
+
+                                        * Gateway (Gateway conformance profile)
+                                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                        This API may be extended in the future to support additional kinds of parent
+                                        resources.
+
+                                        The API object must be valid in the cluster; the Group and Kind must
+                                        be registered in the cluster for this reference to be valid.
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        group:
+                                          description: |-
+                                            Group is the group of the referent.
+                                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                                            To set the core API group (such as for a "Service" kind referent),
+                                            Group must be explicitly set to "" (empty string).
+
+                                            Support: Core
+                                          type: string
+                                          default: gateway.networking.k8s.io
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        kind:
+                                          description: |-
+                                            Kind is kind of the referent.
+
+                                            There are two kinds of parent resources with "Core" support:
+
+                                            * Gateway (Gateway conformance profile)
+                                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                            Support for other resources is Implementation-Specific.
+                                          type: string
+                                          default: Gateway
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        name:
+                                          description: |-
+                                            Name is the name of the referent.
+
+                                            Support: Core
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the referent. When unspecified, this refers
+                                            to the local namespace of the Route.
+
+                                            Note that there are specific rules for ParentRefs which cross namespace
+                                            boundaries. Cross-namespace references are only valid if they are explicitly
+                                            allowed by something in the namespace they are referring to. For example:
+                                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                                            generic way to enable any other kind of cross-namespace reference.
+
+                                            <gateway:experimental:description>
+                                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                                            routes, which apply default routing rules to inbound connections from
+                                            any namespace to the Service.
+
+                                            ParentRefs from a Route to a Service in a different namespace are
+                                            "consumer" routes, and these routing rules are only applied to outbound
+                                            connections originating from the same namespace as the Route, for which
+                                            the intended destination of the connections are a Service targeted as a
+                                            ParentRef of the Route.
+                                            </gateway:experimental:description>
+
+                                            Support: Core
+                                          type: string
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        port:
+                                          description: |-
+                                            Port is the network port this Route targets. It can be interpreted
+                                            differently based on the type of parent resource.
+
+                                            When the parent resource is a Gateway, this targets all listeners
+                                            listening on the specified port that also support this kind of Route(and
+                                            select this Route). It's not recommended to set `Port` unless the
+                                            networking behaviors specified in a Route must apply to a specific port
+                                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                                            and SectionName are specified, the name and port of the selected listener
+                                            must match both specified values.
+
+                                            <gateway:experimental:description>
+                                            When the parent resource is a Service, this targets a specific port in the
+                                            Service spec. When both Port (experimental) and SectionName are specified,
+                                            the name and port of the selected port must match both specified values.
+                                            </gateway:experimental:description>
+
+                                            Implementations MAY choose to support other parent resources.
+                                            Implementations supporting other types of parent resources MUST clearly
+                                            document how/if Port is interpreted.
+
+                                            For the purpose of status, an attachment is considered successful as
+                                            long as the parent resource accepts it partially. For example, Gateway
+                                            listeners can restrict which Routes can attach to them by Route kind,
+                                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                                            from the referencing Route, the Route MUST be considered successfully
+                                            attached. If no Gateway listeners accept attachment from this Route,
+                                            the Route MUST be considered detached from the Gateway.
+
+                                            Support: Extended
+                                          type: integer
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                        sectionName:
+                                          description: |-
+                                            SectionName is the name of a section within the target resource. In the
+                                            following resources, SectionName is interpreted as the following:
+
+                                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                                            are specified, the name and port of the selected listener must match
+                                            both specified values.
+                                            * Service: Port name. When both Port (experimental) and SectionName
+                                            are specified, the name and port of the selected listener must match
+                                            both specified values.
+
+                                            Implementations MAY choose to support attaching Routes to other resources.
+                                            If that is the case, they MUST clearly document how SectionName is
+                                            interpreted.
+
+                                            When unspecified (empty string), this will reference the entire resource.
+                                            For the purpose of status, an attachment is considered successful if at
+                                            least one section in the parent resource accepts it. For example, Gateway
+                                            listeners can restrict which Routes can attach to them by Route kind,
+                                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                                            the referencing Route, the Route MUST be considered successfully
+                                            attached. If no Gateway listeners accept attachment from this Route, the
+                                            Route MUST be considered detached from the Gateway.
+
+                                            Support: Core
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  podTemplate:
+                                    description: |-
+                                      Optional pod template used to configure the ACME challenge solver pods
+                                      used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: |-
+                                          PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                          Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                          All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to an update), the system
+                                                      may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A null or empty node selector term matches no objects. The requirements of
+                                                            them are ANDed.
+                                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                          x-kubernetes-map-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                    x-kubernetes-list-type: atomic
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the anti-affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the anti-affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                    x-kubernetes-list-type: atomic
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            type: array
+                                            items:
+                                              description: |-
+                                                LocalObjectReference contains enough information to let you locate the
+                                                referenced object inside the same namespace.
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                  default: ""
+                                              x-kubernetes-map-type: atomic
+                                          nodeSelector:
+                                            description: |-
+                                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          securityContext:
+                                            description: If specified, the pod's security context
+                                            type: object
+                                            properties:
+                                              fsGroup:
+                                                description: |-
+                                                  A special supplemental group that applies to all containers in a pod.
+                                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                                  to be owned by the pod:
+
+                                                  1. The owning GID will be the FSGroup
+                                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                  3. The permission bits are OR'd with rw-rw----
+
+                                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              fsGroupChangePolicy:
+                                                description: |-
+                                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                  before being exposed inside Pod. This field will only apply to
+                                                  volume types which support fsGroup based ownership(and permissions).
+                                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                  and emptydir.
+                                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to all containers.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in SecurityContext.  If set in
+                                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                  takes precedence for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: object
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by the containers in this pod.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: object
+                                                required:
+                                                  - type
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                              supplementalGroups:
+                                                description: |-
+                                                  A list of groups applied to the first process run in each container, in addition
+                                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                  defined in the container image for the uid of the container process. If unspecified,
+                                                  no additional groups are added to any container. Note that group memberships
+                                                  defined in the container image for the uid of the container process are still effective,
+                                                  even if they are not included in this list.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: array
+                                                items:
+                                                  type: integer
+                                                  format: int64
+                                              sysctls:
+                                                description: |-
+                                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                  sysctls (by the container runtime) might fail to launch.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: array
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  type: object
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: |-
+                                      Optional service type for Kubernetes solver service. Supported values
+                                      are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                              ingress:
+                                description: |-
+                                  The ingress based HTTP01 challenge solver will solve challenges by
+                                  creating or modifying Ingress resources in order to route requests for
+                                  '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
+                                  provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: |-
+                                      This field configures the annotation `kubernetes.io/ingress.class` when
+                                      creating Ingress resources to solve ACME challenges that use this
+                                      challenge solver. Only one of `class`, `name` or `ingressClassName` may
+                                      be specified.
+                                    type: string
+                                  ingressClassName:
+                                    description: |-
+                                      This field configures the field `ingressClassName` on the created Ingress
+                                      resources used to solve ACME challenges that use this challenge solver.
+                                      This is the recommended way of configuring the ingress class. Only one of
+                                      `class`, `name` or `ingressClassName` may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: |-
+                                      Optional ingress template used to configure the ACME challenge solver
+                                      ingress used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the ingress used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: |-
+                                      The name of the ingress resource that should have ACME challenge solving
+                                      routes inserted into it in order to solve HTTP01 challenges.
+                                      This is typically used in conjunction with ingress controllers like
+                                      ingress-gce, which maintains a 1:1 mapping between external IPs and
+                                      ingress resources. Only one of `class`, `name` or `ingressClassName` may
+                                      be specified.
+                                    type: string
+                                  podTemplate:
+                                    description: |-
+                                      Optional pod template used to configure the ACME challenge solver pods
+                                      used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: |-
+                                          PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                          Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                          All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to an update), the system
+                                                      may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A null or empty node selector term matches no objects. The requirements of
+                                                            them are ANDed.
+                                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                          x-kubernetes-map-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                    x-kubernetes-list-type: atomic
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the anti-affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the anti-affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                    x-kubernetes-list-type: atomic
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            type: array
+                                            items:
+                                              description: |-
+                                                LocalObjectReference contains enough information to let you locate the
+                                                referenced object inside the same namespace.
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                  default: ""
+                                              x-kubernetes-map-type: atomic
+                                          nodeSelector:
+                                            description: |-
+                                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          securityContext:
+                                            description: If specified, the pod's security context
+                                            type: object
+                                            properties:
+                                              fsGroup:
+                                                description: |-
+                                                  A special supplemental group that applies to all containers in a pod.
+                                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                                  to be owned by the pod:
+
+                                                  1. The owning GID will be the FSGroup
+                                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                  3. The permission bits are OR'd with rw-rw----
+
+                                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              fsGroupChangePolicy:
+                                                description: |-
+                                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                  before being exposed inside Pod. This field will only apply to
+                                                  volume types which support fsGroup based ownership(and permissions).
+                                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                  and emptydir.
+                                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to all containers.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in SecurityContext.  If set in
+                                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                  takes precedence for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: object
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by the containers in this pod.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: object
+                                                required:
+                                                  - type
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                              supplementalGroups:
+                                                description: |-
+                                                  A list of groups applied to the first process run in each container, in addition
+                                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                  defined in the container image for the uid of the container process. If unspecified,
+                                                  no additional groups are added to any container. Note that group memberships
+                                                  defined in the container image for the uid of the container process are still effective,
+                                                  even if they are not included in this list.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: array
+                                                items:
+                                                  type: integer
+                                                  format: int64
+                                              sysctls:
+                                                description: |-
+                                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                  sysctls (by the container runtime) might fail to launch.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: array
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  type: object
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: |-
+                                      Optional service type for Kubernetes solver service. Supported values
+                                      are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                          selector:
+                            description: |-
+                              Selector selects a set of DNSNames on the Certificate resource that
+                              should be solved using this challenge solver.
+                              If not specified, the solver will be treated as the 'default' solver
+                              with the lowest priority, i.e. if any other solver has a more specific
+                              match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  List of DNSNames that this solver will be used to solve.
+                                  If specified and a match is found, a dnsNames selector will take
+                                  precedence over a dnsZones selector.
+                                  If multiple solvers match with the same dnsNames value, the solver
+                                  with the most matching labels in matchLabels will be selected.
+                                  If neither has more matches, the solver defined earlier in the list
+                                  will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: |-
+                                  List of DNSZones that this solver will be used to solve.
+                                  The most specific DNS zone match specified here will take precedence
+                                  over other DNS zone matches, so a solver specifying sys.example.com
+                                  will be selected over one specifying example.com for the domain
+                                  www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value, the solver
+                                  with the most matching labels in matchLabels will be selected.
+                                  If neither has more matches, the solver defined earlier in the list
+                                  will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: |-
+                                  A label selector that is used to refine the set of certificate's that
+                                  this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: |-
+                    CA configures this issuer to sign certificates using a signing CA keypair
+                    stored in a Secret resource.
+                    This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: |-
+                        The CRL distribution points is an X.509 v3 certificate extension which identifies
+                        the location of the CRL from which the revocation of this certificate can be checked.
+                        If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    issuingCertificateURLs:
+                      description: |-
+                        IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
+                        it creates. See https://www.rfc-editor.org/rfc/rfc5280#section-4.2.2.1 for more details.
+                        As an example, such a URL might be "http://ca.domain.com/ca.crt".
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: |-
+                        The OCSP server list is an X.509 v3 extension that defines a list of
+                        URLs of OCSP responders. The OCSP responders can be queried for the
+                        revocation status of an issued certificate. If not set, the
+                        certificate will be issued with no OCSP servers set. For example, an
+                        OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: |-
+                        SecretName is the name of the secret used to sign Certificates issued
+                        by this Issuer.
+                      type: string
+                selfSigned:
+                  description: |-
+                    SelfSigned configures this issuer to 'self sign' certificates using the
+                    private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: |-
+                        The CRL distribution points is an X.509 v3 certificate extension which identifies
+                        the location of the CRL from which the revocation of this certificate can be checked.
+                        If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: |-
+                    Vault configures this issuer to sign certificates using a HashiCorp Vault
+                    PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: |-
+                            AppRole authenticates with Vault using the App Role auth mechanism,
+                            with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: |-
+                                Path where the App Role authentication backend is mounted in Vault, e.g:
+                                "approle"
+                              type: string
+                            roleId:
+                              description: |-
+                                RoleID configured in the App Role authentication backend when setting
+                                up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: |-
+                                Reference to a key in a Secret that contains the App Role secret used
+                                to authenticate with Vault.
+                                The `key` field must be specified and denotes which entry within the Secret
+                                resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                        clientCertificate:
+                          description: |-
+                            ClientCertificate authenticates with Vault by presenting a client
+                            certificate during the request's TLS handshake.
+                            Works only when using HTTPS protocol.
+                          type: object
+                          properties:
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/cert" will be used.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the certificate role to authenticate against.
+                                If not set, matching any certificate role, if available.
+                              type: string
+                            secretName:
+                              description: |-
+                                Reference to Kubernetes Secret of type "kubernetes.io/tls" (hence containing
+                                tls.crt and tls.key) used to authenticate to Vault using TLS client
+                                authentication.
+                              type: string
+                        kubernetes:
+                          description: |-
+                            Kubernetes authenticates with Vault by passing the ServiceAccount
+                            token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                          properties:
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: |-
+                                A required field containing the Vault Role to assume. A Role binds a
+                                Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: |-
+                                The required Secret field containing a Kubernetes ServiceAccount JWT used
+                                for authenticating with Vault. Use of 'ambient credentials' is not
+                                supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            serviceAccountRef:
+                              description: |-
+                                A reference to a service account that will be used to request a bound
+                                token (also known as "projected token"). Compared to using "secretRef",
+                                using this field means that you don't rely on statically bound tokens. To
+                                use this field, you must configure an RBAC rule to let cert-manager
+                                request a token.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                audiences:
+                                  description: |-
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
+                                    consisting of the issuer's namespace and name is always included.
+                                  type: array
+                                  items:
+                                    type: string
+                                name:
+                                  description: Name of the ServiceAccount used to request a token.
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                    caBundle:
+                      description: |-
+                        Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                        chain presented by Vault. Only used if using HTTPS to connect to Vault and
+                        ignored for HTTP connections.
+                        Mutually exclusive with CABundleSecretRef.
+                        If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    caBundleSecretRef:
+                      description: |-
+                        Reference to a Secret containing a bundle of PEM-encoded CAs to use when
+                        verifying the certificate chain presented by Vault when using HTTPS.
+                        Mutually exclusive with CABundle.
+                        If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                        If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                    clientCertSecretRef:
+                      description: |-
+                        Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+                        Vault server requires mTLS.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                    clientKeySecretRef:
+                      description: |-
+                        Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+                        Vault server requires mTLS.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                    namespace:
+                      description: |-
+                        Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+                        More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                      type: string
+                    path:
+                      description: |-
+                        Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g:
+                        "my_pki_mount/sign/my-role-name".
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: |-
+                    Venafi configures this issuer to sign certificates using a Venafi TPP
+                    or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: |-
+                        Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                        url:
+                          description: |-
+                            URL is the base URL for Venafi Cloud.
+                            Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: |-
+                        TPP specifies Trust Protection Platform configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: |-
+                            Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            If undefined, the certificate bundle in the cert-manager controller container
+                            is used to validate the chain.
+                          type: string
+                          format: byte
+                        caBundleSecretRef:
+                          description: |-
+                            Reference to a Secret containing a base64-encoded bundle of PEM CAs
+                            which will be used to validate the certificate chain presented by the TPP server.
+                            Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
+                            If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
+                            the cert-manager controller container is used to validate the TLS connection.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                        credentialsRef:
+                          description: |-
+                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            The secret must contain the key 'access-token' for the Access Token Authentication,
+                            or two keys, 'username' and 'password' for the API Keys Authentication.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                        url:
+                          description: |-
+                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            for example: "https://tpp.example.com/vedsdk".
+                          type: string
+                    zone:
+                      description: |-
+                        Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by the named
+                        zone policy.
+                        This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: |-
+                    ACME specific status options.
+                    This field should only be set if the Issuer is configured to use an ACME
+                    server to issue certificates.
+                  type: object
+                  properties:
+                    lastPrivateKeyHash:
+                      description: |-
+                        LastPrivateKeyHash is a hash of the private key associated with the latest
+                        registered ACME account, in order to track changes made to registered account
+                        associated with the Issuer
+                      type: string
+                    lastRegisteredEmail:
+                      description: |-
+                        LastRegisteredEmail is the email associated with the latest registered
+                        ACME account, in order to track changes made to registered account
+                        associated with the  Issuer
+                      type: string
+                    uri:
+                      description: |-
+                        URI is the unique account identifier, which can also be used to retrieve
+                        account details from the CA
+                      type: string
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of a CertificateRequest.
+                    Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+      served: true
+      storage: true
+
+# END crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.cert-manager.io
+  # START annotations
+  annotations:
+    helm.sh/resource-policy: keep
+  # END annotations
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/component: "crds"
+    # Generated labels
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  group: cert-manager.io
+  names:
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    singular: issuer
+    categories:
+      - cert-manager
+  scope: Namespaced
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: |-
+            An Issuer represents a certificate issuing authority which can be
+            referenced as part of `issuerRef` fields.
+            It is scoped to a single namespace and can therefore only be referenced by
+            resources within the same namespace.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Issuer resource.
+              type: object
+              properties:
+                acme:
+                  description: |-
+                    ACME configures this issuer to communicate with a RFC8555 (ACME) server
+                    to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    caBundle:
+                      description: |-
+                        Base64-encoded bundle of PEM CAs which can be used to validate the certificate
+                        chain presented by the ACME server.
+                        Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various
+                        kinds of security vulnerabilities.
+                        If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                        the container is used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    disableAccountKeyGeneration:
+                      description: |-
+                        Enables or disables generating a new ACME account key.
+                        If true, the Issuer resource will *not* request a new account but will expect
+                        the account key to be supplied via an existing secret.
+                        If false, the cert-manager system will generate a new ACME account key
+                        for the Issuer.
+                        Defaults to false.
+                      type: boolean
+                    email:
+                      description: |-
+                        Email is the email address to be associated with the ACME account.
+                        This field is optional, but it is strongly recommended to be set.
+                        It will be used to contact you in case of issues with your account or
+                        certificates, including expiry notification emails.
+                        This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: |-
+                        Enables requesting a Not After date on certificates that matches the
+                        duration of the certificate. This is not supported by all ACME servers
+                        like Let's Encrypt. If set to true when the ACME server does not support
+                        it, it will create an error on the Order.
+                        Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: |-
+                        ExternalAccountBinding is a reference to a CA external account of the ACME
+                        server.
+                        If set, upon registration cert-manager will attempt to associate the given
+                        external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: |-
+                            Deprecated: keyAlgorithm field exists for historical compatibility
+                            reasons and should not be used. The algorithm is now hardcoded to HS256
+                            in golang/x/crypto/acme.
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: |-
+                            keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
+                            Secret which holds the symmetric MAC key of the External Account Binding.
+                            The `key` is the index string that is paired with the key data in the
+                            Secret and should not be confused with the key data itself, or indeed with
+                            the External Account Binding keyID above.
+                            The secret key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                    preferredChain:
+                      description: |-
+                        PreferredChain is the chain to use if the ACME server outputs multiple.
+                        PreferredChain is no guarantee that this one gets delivered by the ACME
+                        endpoint.
+                        For example, for Let's Encrypt's DST crosssign you would use:
+                        "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+                        This value picks the first certificate bundle in the combined set of
+                        ACME default and alternative chains that has a root-most certificate with
+                        this value as its issuer's commonname.
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: |-
+                        PrivateKey is the name of a Kubernetes Secret resource that will be used to
+                        store the automatically generated ACME account private key.
+                        Optionally, a `key` may be specified to select a specific entry within
+                        the named Secret resource.
+                        If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                    server:
+                      description: |-
+                        Server is the URL used to access the ACME server's 'directory' endpoint.
+                        For example, for Let's Encrypt's staging endpoint, you would use:
+                        "https://acme-staging-v02.api.letsencrypt.org/directory".
+                        Only ACME v2 endpoints (i.e. RFC 8555) are supported.
+                      type: string
+                    skipTLSVerify:
+                      description: |-
+                        INSECURE: Enables or disables validation of the ACME server TLS certificate.
+                        If true, requests to the ACME server will not have the TLS certificate chain
+                        validated.
+                        Mutually exclusive with CABundle; prefer using CABundle to prevent various
+                        kinds of security vulnerabilities.
+                        Only enable this option in development environments.
+                        If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                        the container is used to validate the TLS connection.
+                        Defaults to false.
+                      type: boolean
+                    solvers:
+                      description: |-
+                        Solvers is a list of challenge solvers that will be used to solve
+                        ACME challenges for the matching domains.
+                        Solver configurations must be provided in order to obtain certificates
+                        from an ACME server.
+                        For more information, see: https://cert-manager.io/docs/configuration/acme/
+                      type: array
+                      items:
+                        description: |-
+                          An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of.
+                          A selector may be provided to use different solving strategies for different DNS names.
+                          Only one of HTTP01 or DNS01 must be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: |-
+                              Configures cert-manager to attempt to complete authorizations by
+                              performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmeDNS:
+                                description: |-
+                                  Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
+                                  DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      The ClientID of the Azure Service Principal used to authenticate with Azure DNS.
+                                      If set, ClientSecret and TenantID must also be set.
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      A reference to a Secret containing the password associated with the Service Principal.
+                                      If set, ClientID and TenantID must also be set.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    description: name of the DNS zone that should be used
+                                    type: string
+                                  managedIdentity:
+                                    description: |-
+                                      Auth: Azure Workload Identity or Azure Managed Service Identity:
+                                      Settings to enable Azure Workload Identity or Azure Managed Service Identity
+                                      If set, ClientID, ClientSecret and TenantID must not be set.
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: |-
+                                          resource ID of the managed identity, can not be used at the same time as clientID
+                                          Cannot be used for Azure Managed Service Identity
+                                        type: string
+                                      tenantID:
+                                        description: tenant ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                  resourceGroupName:
+                                    description: resource group the DNS zone is located in
+                                    type: string
+                                  subscriptionID:
+                                    description: ID of the Azure subscription
+                                    type: string
+                                  tenantID:
+                                    description: |-
+                                      Auth: Azure Service Principal:
+                                      The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
+                                      If set, ClientID and ClientSecret must also be set.
+                                    type: string
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: |-
+                                      HostedZoneName is an optional field that tells cert-manager in which
+                                      Cloud DNS zone the challenge record has to be created.
+                                      If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: |-
+                                      API key to use to authenticate with Cloudflare.
+                                      Note: using an API token to authenticate is now the recommended method
+                                      as it allows greater control of permissions.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: |-
+                                  CNAMEStrategy configures how the DNS01 provider should handle CNAME
+                                  records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: |-
+                                      A reference to a specific 'key' within a Secret resource.
+                                      In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                              rfc2136:
+                                description: |-
+                                  Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                  to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: |-
+                                      The IP address or hostname of an authoritative DNS server supporting
+                                      RFC2136 in the form host:port. If the host is an IPv6 address it must be
+                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: |-
+                                      The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
+                                      when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
+                                      Supported values are (case-insensitive): ``HMACMD5`` (default),
+                                      ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
+                                    type: string
+                                  tsigKeyName:
+                                    description: |-
+                                      The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: |-
+                                      The name of the secret containing the TSIG value.
+                                      If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  accessKeyID:
+                                    description: |-
+                                      The AccessKeyID is used for authentication.
+                                      Cannot be set when SecretAccessKeyID is set.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: string
+                                  accessKeyIDSecretRef:
+                                    description: |-
+                                      The SecretAccessKey is used for authentication. If set, pull the AWS
+                                      access key ID from a key within a Kubernetes Secret.
+                                      Cannot be set when AccessKeyID is set.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                  auth:
+                                    description: Auth configures how cert-manager authenticates.
+                                    type: object
+                                    required:
+                                      - kubernetes
+                                    properties:
+                                      kubernetes:
+                                        description: |-
+                                          Kubernetes authenticates with Route53 using AssumeRoleWithWebIdentity
+                                          by passing a bound ServiceAccount token.
+                                        type: object
+                                        required:
+                                          - serviceAccountRef
+                                        properties:
+                                          serviceAccountRef:
+                                            description: |-
+                                              A reference to a service account that will be used to request a bound
+                                              token (also known as "projected token"). To use this field, you must
+                                              configure an RBAC rule to let cert-manager request a token.
+                                            type: object
+                                            required:
+                                              - name
+                                            properties:
+                                              audiences:
+                                                description: |-
+                                                  TokenAudiences is an optional list of audiences to include in the
+                                                  token passed to AWS. The default token consisting of the issuer's namespace
+                                                  and name is always included.
+                                                  If unset the audience defaults to `sts.amazonaws.com`.
+                                                type: array
+                                                items:
+                                                  type: string
+                                              name:
+                                                description: Name of the ServiceAccount used to request a token.
+                                                type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do a lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: |-
+                                      Override the AWS region.
+
+                                      Route53 is a global service and does not have regional endpoints but the
+                                      region specified here (or via environment variables) is used as a hint to
+                                      help compute the correct AWS credential scope and partition when it
+                                      connects to Route53. See:
+                                      - [Amazon Route 53 endpoints and quotas](https://docs.aws.amazon.com/general/latest/gr/r53.html)
+                                      - [Global services](https://docs.aws.amazon.com/whitepapers/latest/aws-fault-isolation-boundaries/global-services.html)
+
+                                      If you omit this region field, cert-manager will use the region from
+                                      AWS_REGION and AWS_DEFAULT_REGION environment variables, if they are set
+                                      in the cert-manager controller Pod.
+
+                                      The `region` field is not needed if you use [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Webhook](https://github.com/aws/amazon-eks-pod-identity-webhook).
+                                      In this case this `region` field value is ignored.
+
+                                      The `region` field is not needed if you use [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+                                      Instead an AWS_REGION environment variable is added to the cert-manager controller Pod by:
+                                      [Amazon EKS Pod Identity Agent](https://github.com/aws/eks-pod-identity-agent),
+                                      In this case this `region` field value is ignored.
+                                    type: string
+                                  role:
+                                    description: |-
+                                      Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                      or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: |-
+                                      The SecretAccessKey is used for authentication.
+                                      If neither the Access Key nor Key ID are set, we fall-back to using env
+                                      vars, shared credentials file or AWS Instance metadata,
+                                      see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key of the entry in the Secret resource's `data` field to be used.
+                                          Some instances of this field may be defaulted, in others it may be
+                                          required.
+                                        type: string
+                                      name:
+                                        description: |-
+                                          Name of the resource being referred to.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                              webhook:
+                                description: |-
+                                  Configure an external webhook based DNS01 challenge solver to manage
+                                  DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: |-
+                                      Additional configuration that should be passed to the webhook apiserver
+                                      when challenges are processed.
+                                      This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for a DNS service), you
+                                      should use a SecretKeySelector to reference a Secret resource.
+                                      For details on the schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: |-
+                                      The API group name that should be used when POSTing ChallengePayload
+                                      resources to the webhook apiserver.
+                                      This should be the same as the GroupName specified in the webhook
+                                      provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: |-
+                                      The name of the solver to use, as defined in the webhook provider
+                                      implementation.
+                                      This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: |-
+                              Configures cert-manager to attempt to complete authorizations by
+                              performing the HTTP01 challenge flow.
+                              It is not possible to obtain certificates for wildcard domain names
+                              (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: |-
+                                  The Gateway API is a sig-network community API that models service networking
+                                  in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
+                                  create HTTPRoutes with the specified labels in the same namespace as the challenge.
+                                  This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: |-
+                                      Custom labels that will be applied to HTTPRoutes created by cert-manager
+                                      while solving HTTP-01 challenges.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  parentRefs:
+                                    description: |-
+                                      When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+                                      cert-manager needs to know which parentRefs should be used when creating
+                                      the HTTPRoute. Usually, the parentRef references a Gateway. See:
+                                      https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+                                    type: array
+                                    items:
+                                      description: |-
+                                        ParentReference identifies an API object (usually a Gateway) that can be considered
+                                        a parent of this resource (usually a route). There are two kinds of parent resources
+                                        with "Core" support:
+
+                                        * Gateway (Gateway conformance profile)
+                                        * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                        This API may be extended in the future to support additional kinds of parent
+                                        resources.
+
+                                        The API object must be valid in the cluster; the Group and Kind must
+                                        be registered in the cluster for this reference to be valid.
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        group:
+                                          description: |-
+                                            Group is the group of the referent.
+                                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                                            To set the core API group (such as for a "Service" kind referent),
+                                            Group must be explicitly set to "" (empty string).
+
+                                            Support: Core
+                                          type: string
+                                          default: gateway.networking.k8s.io
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        kind:
+                                          description: |-
+                                            Kind is kind of the referent.
+
+                                            There are two kinds of parent resources with "Core" support:
+
+                                            * Gateway (Gateway conformance profile)
+                                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                                            Support for other resources is Implementation-Specific.
+                                          type: string
+                                          default: Gateway
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        name:
+                                          description: |-
+                                            Name is the name of the referent.
+
+                                            Support: Core
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of the referent. When unspecified, this refers
+                                            to the local namespace of the Route.
+
+                                            Note that there are specific rules for ParentRefs which cross namespace
+                                            boundaries. Cross-namespace references are only valid if they are explicitly
+                                            allowed by something in the namespace they are referring to. For example:
+                                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                                            generic way to enable any other kind of cross-namespace reference.
+
+                                            <gateway:experimental:description>
+                                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                                            routes, which apply default routing rules to inbound connections from
+                                            any namespace to the Service.
+
+                                            ParentRefs from a Route to a Service in a different namespace are
+                                            "consumer" routes, and these routing rules are only applied to outbound
+                                            connections originating from the same namespace as the Route, for which
+                                            the intended destination of the connections are a Service targeted as a
+                                            ParentRef of the Route.
+                                            </gateway:experimental:description>
+
+                                            Support: Core
+                                          type: string
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        port:
+                                          description: |-
+                                            Port is the network port this Route targets. It can be interpreted
+                                            differently based on the type of parent resource.
+
+                                            When the parent resource is a Gateway, this targets all listeners
+                                            listening on the specified port that also support this kind of Route(and
+                                            select this Route). It's not recommended to set `Port` unless the
+                                            networking behaviors specified in a Route must apply to a specific port
+                                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                                            and SectionName are specified, the name and port of the selected listener
+                                            must match both specified values.
+
+                                            <gateway:experimental:description>
+                                            When the parent resource is a Service, this targets a specific port in the
+                                            Service spec. When both Port (experimental) and SectionName are specified,
+                                            the name and port of the selected port must match both specified values.
+                                            </gateway:experimental:description>
+
+                                            Implementations MAY choose to support other parent resources.
+                                            Implementations supporting other types of parent resources MUST clearly
+                                            document how/if Port is interpreted.
+
+                                            For the purpose of status, an attachment is considered successful as
+                                            long as the parent resource accepts it partially. For example, Gateway
+                                            listeners can restrict which Routes can attach to them by Route kind,
+                                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                                            from the referencing Route, the Route MUST be considered successfully
+                                            attached. If no Gateway listeners accept attachment from this Route,
+                                            the Route MUST be considered detached from the Gateway.
+
+                                            Support: Extended
+                                          type: integer
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                        sectionName:
+                                          description: |-
+                                            SectionName is the name of a section within the target resource. In the
+                                            following resources, SectionName is interpreted as the following:
+
+                                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                                            are specified, the name and port of the selected listener must match
+                                            both specified values.
+                                            * Service: Port name. When both Port (experimental) and SectionName
+                                            are specified, the name and port of the selected listener must match
+                                            both specified values.
+
+                                            Implementations MAY choose to support attaching Routes to other resources.
+                                            If that is the case, they MUST clearly document how SectionName is
+                                            interpreted.
+
+                                            When unspecified (empty string), this will reference the entire resource.
+                                            For the purpose of status, an attachment is considered successful if at
+                                            least one section in the parent resource accepts it. For example, Gateway
+                                            listeners can restrict which Routes can attach to them by Route kind,
+                                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                                            the referencing Route, the Route MUST be considered successfully
+                                            attached. If no Gateway listeners accept attachment from this Route, the
+                                            Route MUST be considered detached from the Gateway.
+
+                                            Support: Core
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  podTemplate:
+                                    description: |-
+                                      Optional pod template used to configure the ACME challenge solver pods
+                                      used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: |-
+                                          PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                          Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                          All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to an update), the system
+                                                      may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A null or empty node selector term matches no objects. The requirements of
+                                                            them are ANDed.
+                                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                          x-kubernetes-map-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                    x-kubernetes-list-type: atomic
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the anti-affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the anti-affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                    x-kubernetes-list-type: atomic
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            type: array
+                                            items:
+                                              description: |-
+                                                LocalObjectReference contains enough information to let you locate the
+                                                referenced object inside the same namespace.
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                  default: ""
+                                              x-kubernetes-map-type: atomic
+                                          nodeSelector:
+                                            description: |-
+                                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          securityContext:
+                                            description: If specified, the pod's security context
+                                            type: object
+                                            properties:
+                                              fsGroup:
+                                                description: |-
+                                                  A special supplemental group that applies to all containers in a pod.
+                                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                                  to be owned by the pod:
+
+                                                  1. The owning GID will be the FSGroup
+                                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                  3. The permission bits are OR'd with rw-rw----
+
+                                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              fsGroupChangePolicy:
+                                                description: |-
+                                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                  before being exposed inside Pod. This field will only apply to
+                                                  volume types which support fsGroup based ownership(and permissions).
+                                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                  and emptydir.
+                                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to all containers.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in SecurityContext.  If set in
+                                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                  takes precedence for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: object
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by the containers in this pod.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: object
+                                                required:
+                                                  - type
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                              supplementalGroups:
+                                                description: |-
+                                                  A list of groups applied to the first process run in each container, in addition
+                                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                  defined in the container image for the uid of the container process. If unspecified,
+                                                  no additional groups are added to any container. Note that group memberships
+                                                  defined in the container image for the uid of the container process are still effective,
+                                                  even if they are not included in this list.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: array
+                                                items:
+                                                  type: integer
+                                                  format: int64
+                                              sysctls:
+                                                description: |-
+                                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                  sysctls (by the container runtime) might fail to launch.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: array
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  type: object
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: |-
+                                      Optional service type for Kubernetes solver service. Supported values
+                                      are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                              ingress:
+                                description: |-
+                                  The ingress based HTTP01 challenge solver will solve challenges by
+                                  creating or modifying Ingress resources in order to route requests for
+                                  '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
+                                  provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: |-
+                                      This field configures the annotation `kubernetes.io/ingress.class` when
+                                      creating Ingress resources to solve ACME challenges that use this
+                                      challenge solver. Only one of `class`, `name` or `ingressClassName` may
+                                      be specified.
+                                    type: string
+                                  ingressClassName:
+                                    description: |-
+                                      This field configures the field `ingressClassName` on the created Ingress
+                                      resources used to solve ACME challenges that use this challenge solver.
+                                      This is the recommended way of configuring the ingress class. Only one of
+                                      `class`, `name` or `ingressClassName` may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: |-
+                                      Optional ingress template used to configure the ACME challenge solver
+                                      ingress used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the ingress used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: |-
+                                      The name of the ingress resource that should have ACME challenge solving
+                                      routes inserted into it in order to solve HTTP01 challenges.
+                                      This is typically used in conjunction with ingress controllers like
+                                      ingress-gce, which maintains a 1:1 mapping between external IPs and
+                                      ingress resources. Only one of `class`, `name` or `ingressClassName` may
+                                      be specified.
+                                    type: string
+                                  podTemplate:
+                                    description: |-
+                                      Optional pod template used to configure the ACME challenge solver pods
+                                      used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                          Only the 'labels' and 'annotations' fields may be set.
+                                          If labels or annotations overlap with in-built values, the values here
+                                          will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: |-
+                                          PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                          Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                          All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to an update), the system
+                                                      may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: |-
+                                                            A null or empty node selector term matches no objects. The requirements of
+                                                            them are ANDed.
+                                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                                  that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      An array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                                      array must have a single element, which will be interpreted as an integer.
+                                                                      This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                          x-kubernetes-map-type: atomic
+                                                        x-kubernetes-list-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                    x-kubernetes-list-type: atomic
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified by this field, but it may choose
+                                                      a node that violates one or more of the expressions. The node that is
+                                                      most preferred is the one with the greatest sum of weights, i.e.
+                                                      for each node that meets all of the scheduling requirements (resource
+                                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through the elements of this field and adding
+                                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                      node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: |-
+                                                                A label query over a set of resources, in this case pods.
+                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            matchLabelKeys:
+                                                              description: |-
+                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            mismatchLabelKeys:
+                                                              description: |-
+                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                pod labels will be ignored. The default value is empty.
+                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            namespaceSelector:
+                                                              description: |-
+                                                                A label query over the set of namespaces that the term applies to.
+                                                                The term is applied to the union of the namespaces selected by this field
+                                                                and the ones listed in the namespaces field.
+                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: |-
+                                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                      relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: |-
+                                                                          operator represents a key's relationship to a set of values.
+                                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: |-
+                                                                          values is an array of string values. If the operator is In or NotIn,
+                                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                          the values array must be empty. This array is replaced during a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                        x-kubernetes-list-type: atomic
+                                                                  x-kubernetes-list-type: atomic
+                                                                matchLabels:
+                                                                  description: |-
+                                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: |-
+                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                The term is applied to the union of the namespaces listed in this field
+                                                                and the ones selected by namespaceSelector.
+                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                              x-kubernetes-list-type: atomic
+                                                            topologyKey:
+                                                              description: |-
+                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                selected pods is running.
+                                                                Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: |-
+                                                            weight associated with matching the corresponding podAffinityTerm,
+                                                            in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                    x-kubernetes-list-type: atomic
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: |-
+                                                      If the anti-affinity requirements specified by this field are not met at
+                                                      scheduling time, the pod will not be scheduled onto the node.
+                                                      If the anti-affinity requirements specified by this field cease to be met
+                                                      at some point during pod execution (e.g. due to a pod label update), the
+                                                      system may or may not try to eventually evict the pod from its node.
+                                                      When there are multiple elements, the lists of nodes corresponding to each
+                                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: |-
+                                                        Defines a set of pods (namely those matching the labelSelector
+                                                        relative to the given namespace(s)) that this pod should be
+                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                        where co-located is defined as running on a node whose value of
+                                                        the label with key <topologyKey> matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            A label query over a set of resources, in this case pods.
+                                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        matchLabelKeys:
+                                                          description: |-
+                                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        mismatchLabelKeys:
+                                                          description: |-
+                                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                            be taken into consideration. The keys are used to lookup values from the
+                                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                            to select the group of existing pods which pods will be taken into consideration
+                                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                            pod labels will be ignored. The default value is empty.
+                                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        namespaceSelector:
+                                                          description: |-
+                                                            A label query over the set of namespaces that the term applies to.
+                                                            The term is applied to the union of the namespaces selected by this field
+                                                            and the ones listed in the namespaces field.
+                                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                                            An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                                    x-kubernetes-list-type: atomic
+                                                              x-kubernetes-list-type: atomic
+                                                            matchLabels:
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: |-
+                                                            namespaces specifies a static list of namespace names that the term applies to.
+                                                            The term is applied to the union of the namespaces listed in this field
+                                                            and the ones selected by namespaceSelector.
+                                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                          x-kubernetes-list-type: atomic
+                                                        topologyKey:
+                                                          description: |-
+                                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                                            selected pods is running.
+                                                            Empty topologyKey is not allowed.
+                                                          type: string
+                                                    x-kubernetes-list-type: atomic
+                                          imagePullSecrets:
+                                            description: If specified, the pod's imagePullSecrets
+                                            type: array
+                                            items:
+                                              description: |-
+                                                LocalObjectReference contains enough information to let you locate the
+                                                referenced object inside the same namespace.
+                                              type: object
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                  default: ""
+                                              x-kubernetes-map-type: atomic
+                                          nodeSelector:
+                                            description: |-
+                                              NodeSelector is a selector which must be true for the pod to fit on a node.
+                                              Selector which must match a node's labels for the pod to be scheduled on that node.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          securityContext:
+                                            description: If specified, the pod's security context
+                                            type: object
+                                            properties:
+                                              fsGroup:
+                                                description: |-
+                                                  A special supplemental group that applies to all containers in a pod.
+                                                  Some volume types allow the Kubelet to change the ownership of that volume
+                                                  to be owned by the pod:
+
+                                                  1. The owning GID will be the FSGroup
+                                                  2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                  3. The permission bits are OR'd with rw-rw----
+
+                                                  If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              fsGroupChangePolicy:
+                                                description: |-
+                                                  fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                  before being exposed inside Pod. This field will only apply to
+                                                  volume types which support fsGroup based ownership(and permissions).
+                                                  It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                  and emptydir.
+                                                  Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in SecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                  for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: integer
+                                                format: int64
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to all containers.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in SecurityContext.  If set in
+                                                  both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                  takes precedence for that container.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: object
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by the containers in this pod.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: object
+                                                required:
+                                                  - type
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                              supplementalGroups:
+                                                description: |-
+                                                  A list of groups applied to the first process run in each container, in addition
+                                                  to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                  defined in the container image for the uid of the container process. If unspecified,
+                                                  no additional groups are added to any container. Note that group memberships
+                                                  defined in the container image for the uid of the container process are still effective,
+                                                  even if they are not included in this list.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: array
+                                                items:
+                                                  type: integer
+                                                  format: int64
+                                              sysctls:
+                                                description: |-
+                                                  Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                  sysctls (by the container runtime) might fail to launch.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: array
+                                                items:
+                                                  description: Sysctl defines a kernel parameter to be set
+                                                  type: object
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  properties:
+                                                    name:
+                                                      description: Name of a property to set
+                                                      type: string
+                                                    value:
+                                                      description: Value of a property to set
+                                                      type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: |-
+                                                The pod this Toleration is attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: |-
+                                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: |-
+                                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Operator represents a key's relationship to the value.
+                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Exists is equivalent to wildcard for value, so that a pod can
+                                                    tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: |-
+                                                    TolerationSeconds represents the period of time the toleration (which must be
+                                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                    negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: |-
+                                                    Value is the taint value the toleration matches to.
+                                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: |-
+                                      Optional service type for Kubernetes solver service. Supported values
+                                      are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                          selector:
+                            description: |-
+                              Selector selects a set of DNSNames on the Certificate resource that
+                              should be solved using this challenge solver.
+                              If not specified, the solver will be treated as the 'default' solver
+                              with the lowest priority, i.e. if any other solver has a more specific
+                              match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  List of DNSNames that this solver will be used to solve.
+                                  If specified and a match is found, a dnsNames selector will take
+                                  precedence over a dnsZones selector.
+                                  If multiple solvers match with the same dnsNames value, the solver
+                                  with the most matching labels in matchLabels will be selected.
+                                  If neither has more matches, the solver defined earlier in the list
+                                  will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: |-
+                                  List of DNSZones that this solver will be used to solve.
+                                  The most specific DNS zone match specified here will take precedence
+                                  over other DNS zone matches, so a solver specifying sys.example.com
+                                  will be selected over one specifying example.com for the domain
+                                  www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value, the solver
+                                  with the most matching labels in matchLabels will be selected.
+                                  If neither has more matches, the solver defined earlier in the list
+                                  will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: |-
+                                  A label selector that is used to refine the set of certificate's that
+                                  this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: |-
+                    CA configures this issuer to sign certificates using a signing CA keypair
+                    stored in a Secret resource.
+                    This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: |-
+                        The CRL distribution points is an X.509 v3 certificate extension which identifies
+                        the location of the CRL from which the revocation of this certificate can be checked.
+                        If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    issuingCertificateURLs:
+                      description: |-
+                        IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
+                        it creates. See https://www.rfc-editor.org/rfc/rfc5280#section-4.2.2.1 for more details.
+                        As an example, such a URL might be "http://ca.domain.com/ca.crt".
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: |-
+                        The OCSP server list is an X.509 v3 extension that defines a list of
+                        URLs of OCSP responders. The OCSP responders can be queried for the
+                        revocation status of an issued certificate. If not set, the
+                        certificate will be issued with no OCSP servers set. For example, an
+                        OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: |-
+                        SecretName is the name of the secret used to sign Certificates issued
+                        by this Issuer.
+                      type: string
+                selfSigned:
+                  description: |-
+                    SelfSigned configures this issuer to 'self sign' certificates using the
+                    private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: |-
+                        The CRL distribution points is an X.509 v3 certificate extension which identifies
+                        the location of the CRL from which the revocation of this certificate can be checked.
+                        If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: |-
+                    Vault configures this issuer to sign certificates using a HashiCorp Vault
+                    PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: |-
+                            AppRole authenticates with Vault using the App Role auth mechanism,
+                            with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: |-
+                                Path where the App Role authentication backend is mounted in Vault, e.g:
+                                "approle"
+                              type: string
+                            roleId:
+                              description: |-
+                                RoleID configured in the App Role authentication backend when setting
+                                up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: |-
+                                Reference to a key in a Secret that contains the App Role secret used
+                                to authenticate with Vault.
+                                The `key` field must be specified and denotes which entry within the Secret
+                                resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                        clientCertificate:
+                          description: |-
+                            ClientCertificate authenticates with Vault by presenting a client
+                            certificate during the request's TLS handshake.
+                            Works only when using HTTPS protocol.
+                          type: object
+                          properties:
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/cert" will be used.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the certificate role to authenticate against.
+                                If not set, matching any certificate role, if available.
+                              type: string
+                            secretName:
+                              description: |-
+                                Reference to Kubernetes Secret of type "kubernetes.io/tls" (hence containing
+                                tls.crt and tls.key) used to authenticate to Vault using TLS client
+                                authentication.
+                              type: string
+                        kubernetes:
+                          description: |-
+                            Kubernetes authenticates with Vault by passing the ServiceAccount
+                            token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                          properties:
+                            mountPath:
+                              description: |-
+                                The Vault mountPath here is the mount path to use when authenticating with
+                                Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: |-
+                                A required field containing the Vault Role to assume. A Role binds a
+                                Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: |-
+                                The required Secret field containing a Kubernetes ServiceAccount JWT used
+                                for authenticating with Vault. Use of 'ambient credentials' is not
+                                supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: |-
+                                    The key of the entry in the Secret resource's `data` field to be used.
+                                    Some instances of this field may be defaulted, in others it may be
+                                    required.
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the resource being referred to.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                            serviceAccountRef:
+                              description: |-
+                                A reference to a service account that will be used to request a bound
+                                token (also known as "projected token"). Compared to using "secretRef",
+                                using this field means that you don't rely on statically bound tokens. To
+                                use this field, you must configure an RBAC rule to let cert-manager
+                                request a token.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                audiences:
+                                  description: |-
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
+                                    consisting of the issuer's namespace and name is always included.
+                                  type: array
+                                  items:
+                                    type: string
+                                name:
+                                  description: Name of the ServiceAccount used to request a token.
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                    caBundle:
+                      description: |-
+                        Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                        chain presented by Vault. Only used if using HTTPS to connect to Vault and
+                        ignored for HTTP connections.
+                        Mutually exclusive with CABundleSecretRef.
+                        If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    caBundleSecretRef:
+                      description: |-
+                        Reference to a Secret containing a bundle of PEM-encoded CAs to use when
+                        verifying the certificate chain presented by Vault when using HTTPS.
+                        Mutually exclusive with CABundle.
+                        If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                        the cert-manager controller container is used to validate the TLS connection.
+                        If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                    clientCertSecretRef:
+                      description: |-
+                        Reference to a Secret containing a PEM-encoded Client Certificate to use when the
+                        Vault server requires mTLS.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                    clientKeySecretRef:
+                      description: |-
+                        Reference to a Secret containing a PEM-encoded Client Private Key to use when the
+                        Vault server requires mTLS.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: |-
+                            The key of the entry in the Secret resource's `data` field to be used.
+                            Some instances of this field may be defaulted, in others it may be
+                            required.
+                          type: string
+                        name:
+                          description: |-
+                            Name of the resource being referred to.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                    namespace:
+                      description: |-
+                        Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+                        More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                      type: string
+                    path:
+                      description: |-
+                        Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g:
+                        "my_pki_mount/sign/my-role-name".
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: |-
+                    Venafi configures this issuer to sign certificates using a Venafi TPP
+                    or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: |-
+                        Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                        url:
+                          description: |-
+                            URL is the base URL for Venafi Cloud.
+                            Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: |-
+                        TPP specifies Trust Protection Platform configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: |-
+                            Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            If undefined, the certificate bundle in the cert-manager controller container
+                            is used to validate the chain.
+                          type: string
+                          format: byte
+                        caBundleSecretRef:
+                          description: |-
+                            Reference to a Secret containing a base64-encoded bundle of PEM CAs
+                            which will be used to validate the certificate chain presented by the TPP server.
+                            Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
+                            If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
+                            the cert-manager controller container is used to validate the TLS connection.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: |-
+                                The key of the entry in the Secret resource's `data` field to be used.
+                                Some instances of this field may be defaulted, in others it may be
+                                required.
+                              type: string
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                        credentialsRef:
+                          description: |-
+                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            The secret must contain the key 'access-token' for the Access Token Authentication,
+                            or two keys, 'username' and 'password' for the API Keys Authentication.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: |-
+                                Name of the resource being referred to.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                        url:
+                          description: |-
+                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            for example: "https://tpp.example.com/vedsdk".
+                          type: string
+                    zone:
+                      description: |-
+                        Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by the named
+                        zone policy.
+                        This field is required.
+                      type: string
+            status:
+              description: Status of the Issuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: |-
+                    ACME specific status options.
+                    This field should only be set if the Issuer is configured to use an ACME
+                    server to issue certificates.
+                  type: object
+                  properties:
+                    lastPrivateKeyHash:
+                      description: |-
+                        LastPrivateKeyHash is a hash of the private key associated with the latest
+                        registered ACME account, in order to track changes made to registered account
+                        associated with the Issuer
+                      type: string
+                    lastRegisteredEmail:
+                      description: |-
+                        LastRegisteredEmail is the email associated with the latest registered
+                        ACME account, in order to track changes made to registered account
+                        associated with the  Issuer
+                      type: string
+                    uri:
+                      description: |-
+                        URI is the unique account identifier, which can also be used to retrieve
+                        account details from the CA
+                      type: string
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of a CertificateRequest.
+                    Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: |-
+                          Message is a human readable description of the details of the last
+                          transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: |-
+                          Reason is a brief machine readable explanation for the condition's last
+                          transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+      served: true
+      storage: true
+
+# END crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: orders.acme.cert-manager.io
+  # START annotations
+  annotations:
+    helm.sh/resource-policy: keep
+  # END annotations
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    app.kubernetes.io/component: "crds"
+    # Generated labels
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  group: acme.cert-manager.io
+  names:
+    kind: Order
+    listKind: OrderList
+    plural: orders
+    singular: order
+    categories:
+      - cert-manager
+      - cert-manager-acme
+  scope: Namespaced
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - issuerRef
+                - request
+              properties:
+                commonName:
+                  description: |-
+                    CommonName is the common name as specified on the DER encoded CSR.
+                    If specified, this value must also be present in `dnsNames` or `ipAddresses`.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  type: string
+                dnsNames:
+                  description: |-
+                    DNSNames is a list of DNS names that should be included as part of the Order
+                    validation process.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                duration:
+                  description: |-
+                    Duration is the duration for the not after date for the requested certificate.
+                    this is set on order creation as pe the ACME spec.
+                  type: string
+                ipAddresses:
+                  description: |-
+                    IPAddresses is a list of IP addresses that should be included as part of the Order
+                    validation process.
+                    This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                issuerRef:
+                  description: |-
+                    IssuerRef references a properly configured ACME-type Issuer which should
+                    be used to create this Order.
+                    If the Issuer does not exist, processing will be retried.
+                    If the Issuer is not an 'ACME' Issuer, an error will be returned and the
+                    Order will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                request:
+                  description: |-
+                    Certificate signing request bytes in DER encoding.
+                    This will be used when finalizing the order.
+                    This field must be set on the order.
+                  type: string
+                  format: byte
+            status:
+              type: object
+              properties:
+                authorizations:
+                  description: |-
+                    Authorizations contains data returned from the ACME server on what
+                    authorizations must be completed in order to validate the DNS names
+                    specified on the Order.
+                  type: array
+                  items:
+                    description: |-
+                      ACMEAuthorization contains data returned from the ACME server on an
+                      authorization that must be completed in order validate a DNS name on an ACME
+                      Order resource.
+                    type: object
+                    required:
+                      - url
+                    properties:
+                      challenges:
+                        description: |-
+                          Challenges specifies the challenge types offered by the ACME server.
+                          One of these challenge types will be selected when validating the DNS
+                          name and an appropriate Challenge resource will be created to perform
+                          the ACME challenge process.
+                        type: array
+                        items:
+                          description: |-
+                            Challenge specifies a challenge offered by the ACME server for an Order.
+                            An appropriate Challenge resource can be created to perform the ACME
+                            challenge process.
+                          type: object
+                          required:
+                            - token
+                            - type
+                            - url
+                          properties:
+                            token:
+                              description: |-
+                                Token is the token that must be presented for this challenge.
+                                This is used to compute the 'key' that must also be presented.
+                              type: string
+                            type:
+                              description: |-
+                                Type is the type of challenge being offered, e.g. 'http-01', 'dns-01',
+                                'tls-sni-01', etc.
+                                This is the raw value retrieved from the ACME server.
+                                Only 'http-01' and 'dns-01' are supported by cert-manager, other values
+                                will be ignored.
+                              type: string
+                            url:
+                              description: |-
+                                URL is the URL of this challenge. It can be used to retrieve additional
+                                metadata about the Challenge from the ACME server.
+                              type: string
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part of this authorization
+                        type: string
+                      initialState:
+                        description: |-
+                          InitialState is the initial state of the ACME authorization when first
+                          fetched from the ACME server.
+                          If an Authorization is already 'valid', the Order controller will not
+                          create a Challenge resource for the authorization. This will occur when
+                          working with an ACME server that enables 'authz reuse' (such as Let's
+                          Encrypt's production endpoint).
+                          If not set and 'identifier' is set, the state is assumed to be pending
+                          and a Challenge will be created.
+                        type: string
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                      url:
+                        description: URL is the URL of the Authorization that must be completed
+                        type: string
+                      wildcard:
+                        description: |-
+                          Wildcard will be true if this authorization is for a wildcard DNS name.
+                          If this is true, the identifier will be the *non-wildcard* version of
+                          the DNS name.
+                          For example, if '*.example.com' is the DNS name being validated, this
+                          field will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                certificate:
+                  description: |-
+                    Certificate is a copy of the PEM encoded certificate for this Order.
+                    This field will be populated after the order has been successfully
+                    finalized with the ACME server, and the order has transitioned to the
+                    'valid' state.
+                  type: string
+                  format: byte
+                failureTime:
+                  description: |-
+                    FailureTime stores the time that this order failed.
+                    This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+                finalizeURL:
+                  description: |-
+                    FinalizeURL of the Order.
+                    This is used to obtain certificates for this order once it has been completed.
+                  type: string
+                reason:
+                  description: |-
+                    Reason optionally provides more information about a why the order is in
+                    the current state.
+                  type: string
+                state:
+                  description: |-
+                    State contains the current state of this Order resource.
+                    States 'success' and 'expired' are 'final'
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                url:
+                  description: |-
+                    URL of the Order.
+                    This will initially be empty when the resource is first created.
+                    The Order controller will populate this field when the Order is first processed.
+                    This field will be immutable after it is initially set.
+                  type: string
+      served: true
+      storage: true
+# END crd
+---
+# Source: cert-manager/templates/crds.yaml
+#
+# START crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/templates/webhook-mutating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: cert-manager-webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"
+  annotations:
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
+webhooks:
+  - name: webhook.cert-manager.io
+    rules:
+      - apiGroups:
+          - "cert-manager.io"
+        apiVersions:
+          - "v1"
+        operations:
+          - CREATE
+        resources:
+          - "certificaterequests"
+    admissionReviewVersions: ["v1"]
+    # This webhook only accepts v1 cert-manager resources.
+    # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
+    # this webhook (after the resources have been converted to v1).
+    matchPolicy: Equivalent
+    timeoutSeconds: 30
+    failurePolicy: Fail
+    # Only include 'sideEffects' field in Kubernetes 1.12+
+    sideEffects: None
+    clientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /mutate
+---
+# Source: cert-manager/templates/webhook-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: cert-manager-webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"
+  annotations:
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
+webhooks:
+  - name: webhook.cert-manager.io
+    namespaceSelector:
+      matchExpressions:
+      - key: cert-manager.io/disable-validation
+        operator: NotIn
+        values:
+        - "true"
+    rules:
+      - apiGroups:
+          - "cert-manager.io"
+          - "acme.cert-manager.io"
+        apiVersions:
+          - "v1"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    admissionReviewVersions: ["v1"]
+    # This webhook only accepts v1 cert-manager resources.
+    # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
+    # this webhook (after the resources have been converted to v1).
+    matchPolicy: Equivalent
+    timeoutSeconds: 30
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /validate

--- a/infrastructure/controllers/base/03-cert-manager/00-namespace.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/00-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager

--- a/infrastructure/controllers/base/03-cert-manager/01-cluster-role.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/01-cluster-role.yaml
@@ -1,0 +1,383 @@
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "create", "update", "patch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Issuer controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "issuers/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# ClusterIssuer controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "clusterissuers/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Certificates controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/finalizers", "certificaterequests/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Orders controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "orders/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "challenges"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["create", "delete"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Challenges controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  # Use to update challenge resource status
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "challenges/status"]
+    verbs: ["update", "patch"]
+  # Used to watch challenge resources
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["get", "list", "watch"]
+  # Used to watch challenges, issuer and clusterissuer resources
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  # Need to be able to retrieve ACME account private key to complete challenges
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  # Used to create events
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # HTTP01 rules
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [ "gateway.networking.k8s.io" ]
+    resources: [ "httproutes" ]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  # We require the ability to specify a custom hostname when we are creating
+  # new ingress resources.
+  # See: https://github.com/openshift/origin/blob/21f191775636f9acadb44fa42beeb4f75b255532/pkg/route/apiserver/admission/ingress_admission.go#L84-L148
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes/custom-host"]
+    verbs: ["create"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges/finalizers"]
+    verbs: ["update"]
+  # DNS01 rules (duplicated above)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# ingress-shim controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests"]
+    verbs: ["create", "update", "delete"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways", "httproutes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways/finalizers", "httproutes/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-cluster-view
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-view
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "orders"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-edit
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/status"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "orders"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-approve:cert-manager-io
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cert-manager"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["signers"]
+    verbs: ["approve"]
+    resourceNames:
+    - "issuers.cert-manager.io/*"
+    - "clusterissuers.cert-manager.io/*"
+---
+# Source: cert-manager/templates/rbac.yaml
+# Permission to:
+# - Update and sign CertificateSigningRequests referencing cert-manager.io Issuers and ClusterIssuers
+# - Perform SubjectAccessReviews to test whether users are able to reference Namespaced Issuers
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-controller-certificatesigningrequests
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cert-manager"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["signers"]
+    resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+    verbs: ["sign"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-webhook:subjectaccessreviews
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]

--- a/infrastructure/controllers/base/03-cert-manager/01-role.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/01-role.yaml
@@ -1,0 +1,89 @@
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+# leader election rules
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  # Used for leader election by the controller
+  # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
+  #   see cmd/cainjector/start.go#L113
+  # cert-manager-cainjector-leader-election-core is used by the SecretBased injector controller
+  #   see cmd/cainjector/start.go#L137
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cert-manager-controller"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-tokenrequest
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    resourceNames: ["cert-manager"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-webhook:dynamic-serving
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+  - 'cert-manager-webhook-ca'
+  verbs: ["get", "list", "watch", "update"]
+# It's not possible to grant CREATE permission on a single resourceName.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]

--- a/infrastructure/controllers/base/03-cert-manager/01-service-accounts.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/01-service-accounts.yaml
@@ -1,0 +1,42 @@
+---
+# Source: cert-manager/templates/cainjector-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: cert-manager-cainjector
+  namespace: cert-manager
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.17.0"
+---
+# Source: cert-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+---
+# Source: cert-manager/templates/webhook-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: cert-manager-webhook
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"

--- a/infrastructure/controllers/base/03-cert-manager/02-cluster-role-binding.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/02-cluster-role-binding.yaml
@@ -1,0 +1,200 @@
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-cainjector
+subjects:
+  - name: cert-manager-cainjector
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-issuers
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-clusterissuers
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificates
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-orders
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-challenges
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-ingress-shim
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-approve:cert-manager-io
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cert-manager"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-approve:cert-manager-io
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-controller-certificatesigningrequests
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cert-manager"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificatesigningrequests
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-webhook:subjectaccessreviews
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-webhook:subjectaccessreviews
+subjects:
+- kind: ServiceAccount
+  name: cert-manager-webhook
+  namespace: cert-manager

--- a/infrastructure/controllers/base/03-cert-manager/02-role-binding.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/02-role-binding.yaml
@@ -1,0 +1,89 @@
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-cainjector:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager-cainjector
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/rbac.yaml
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/rbac.yaml
+# grant cert-manager permission to create tokens for the serviceaccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-cert-manager-tokenrequest
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-tokenrequest
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-webhook:dynamic-serving
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-webhook:dynamic-serving
+subjects:
+- kind: ServiceAccount
+  name: cert-manager-webhook
+  namespace: cert-manager

--- a/infrastructure/controllers/base/03-cert-manager/03-deployment.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/03-deployment.yaml
@@ -1,0 +1,240 @@
+---
+# Source: cert-manager/templates/cainjector-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager-cainjector
+  namespace: cert-manager
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "cainjector"
+  template:
+    metadata:
+      labels:
+        app: cainjector
+        app.kubernetes.io/name: cainjector
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "cainjector"
+        app.kubernetes.io/version: "v1.17.0"
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9402'
+    spec:
+      serviceAccountName: cert-manager-cainjector
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cert-manager-cainjector
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.17.0"
+          imagePullPolicy: IfNotPresent
+          args:
+          - --v=2
+          - --leader-election-namespace=kube-system
+          ports:
+          - containerPort: 9402
+            name: http-metrics
+            protocol: TCP
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: cert-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "controller"
+  template:
+    metadata:
+      labels:
+        app: cert-manager
+        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "controller"
+        app.kubernetes.io/version: "v1.17.0"
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9402'
+    spec:
+      serviceAccountName: cert-manager
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cert-manager-controller
+          image: "quay.io/jetstack/cert-manager-controller:v1.17.0"
+          imagePullPolicy: IfNotPresent
+          args:
+          - --v=2
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+          - --leader-election-namespace=kube-system
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.17.0
+          - --max-concurrent-challenges=60
+          ports:
+          - containerPort: 9402
+            name: http-metrics
+            protocol: TCP
+          - containerPort: 9403
+            name: http-healthz
+            protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          # LivenessProbe settings are based on those used for the Kubernetes
+          # controller-manager. See:
+          # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
+          livenessProbe:
+            httpGet:
+              port: http-healthz
+              path: /livez
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 15
+            successThreshold: 1
+            failureThreshold: 8
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: cert-manager/templates/webhook-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cert-manager-webhook
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "webhook"
+  template:
+    metadata:
+      labels:
+        app: webhook
+        app.kubernetes.io/name: webhook
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "webhook"
+        app.kubernetes.io/version: "v1.17.0"
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9402'
+    spec:
+      serviceAccountName: cert-manager-webhook
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cert-manager-webhook
+          image: "quay.io/jetstack/cert-manager-webhook:v1.17.0"
+          imagePullPolicy: IfNotPresent
+          args:
+          - --v=2
+          - --secure-port=10250
+          - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
+          - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
+          - --dynamic-serving-dns-names=cert-manager-webhook
+          - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE)
+          - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE).svc
+          
+          ports:
+          - name: https
+            protocol: TCP
+            containerPort: 10250
+          - name: healthcheck
+            protocol: TCP
+            containerPort: 6080
+          - containerPort: 9402
+            name: http-metrics
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/infrastructure/controllers/base/03-cert-manager/04-service.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/04-service.yaml
@@ -1,0 +1,75 @@
+---
+# Source: cert-manager/templates/cainjector-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager-cainjector
+  namespace: cert-manager
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 9402
+    name: http-metrics
+  selector:
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+---
+# Source: cert-manager/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 9402
+    name: tcp-prometheus-servicemonitor
+    targetPort: 9402
+  selector:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+---
+# Source: cert-manager/templates/webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: cert-manager-webhook
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.17.0"
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: "https"
+  - name: metrics
+    port: 9402
+    protocol: TCP
+    targetPort: "http-metrics"
+  selector:
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"

--- a/infrastructure/controllers/base/03-cert-manager/10-cluster-issuer.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/10-cluster-issuer.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: tommahs@tommahs.nl
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        ingress:
+          ingressClassName: traefik
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: tommahs@tommahs.nl
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+    - http01:
+        ingress:
+          ingressClassName: traefik
+---

--- a/infrastructure/controllers/base/03-cert-manager/10-issuer.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/10-issuer.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: tommahs@tommahs.nl
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      - http01:
+          ingress:
+            ingressClassName: traefik

--- a/infrastructure/controllers/base/03-cert-manager/11-troubleshoot.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/11-troubleshoot.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: debug-tools
+  namespace: cert-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: debug-tools
+  template:
+    metadata:
+      labels:
+        app: debug-tools
+    spec:
+      containers:
+        - name: debug-tools
+          image: curlimages/curl:latest
+          command: ["sh", "-c", "sleep infinity"]
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              cpu: "100m"
+              memory: "128Mi"
+            requests:
+              cpu: "50m"
+              memory: "64Mi"

--- a/infrastructure/controllers/base/03-cert-manager/kustomization.yaml
+++ b/infrastructure/controllers/base/03-cert-manager/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: pathfinderwiki
+resources:
+  - 00-crds.yaml
+  - 00-namespace.yaml
+  - 01-cluster-role.yaml
+  - 01-role.yaml
+  - 01-service-accounts.yaml
+  - 02-cluster-role-binding.yaml
+  - 02-role-binding.yaml
+  - 03-deployment.yaml
+  - 04-service.yaml
+  - 05-cilium-network-policy.yaml 
+  - 10-cluster-issuer.yaml

--- a/monitoring/controllers/base/grafana/values.yaml
+++ b/monitoring/controllers/base/grafana/values.yaml
@@ -1,0 +1,30 @@
+# Grafana service configuration
+service:
+  type: ClusterIP
+
+# Admin credentials
+adminUser: admin
+adminPassword: your-secure-password  # Change this!
+
+# Disable default ingress as we'll use Traefik IngressRoute
+ingress:
+  enabled: false
+
+# Basic persistence
+persistence:
+  enabled: true
+  size: 10Gi
+
+# Traefik IngressRoute configuration
+ingressRoute:
+  dashboard:
+    # This will create a Traefik IngressRoute CRD
+    enabled: true
+    # Use both HTTP and HTTPS endpoints
+    entryPoints: ["web", "websecure"]
+    # Your domain configuration
+    match: Host(`grafana.example.com`)  # Replace with your domain
+    # Point to the Grafana service
+    service:
+      name: grafana
+      port: 80

--- a/terraform/ceph/main.tf
+++ b/terraform/ceph/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+# Base image for the VM
+resource "libvirt_volume" "base_arch_qcow2" {
+  name   = "base-arch.qcow2"
+  pool   = "homelab_ceph"
+  source = var.vm_image_path  # Path to the base image
+  format = "qcow2"
+}
+# Defining nodes
+resource "libvirt_volume" "ceph_disk" {
+  count  = 3
+  name   = "ceph${count.index + 1}.qcow2"
+  pool   = "homelab_ceph"
+  source = libvirt_volume.base_arch_qcow2.id
+  format = "qcow2"
+  size   = 41943040
+}
+# Define the node using the new 50GB disk
+resource "libvirt_domain" "ceph_node" {
+  count    = 3
+  name     = "ceph${count.index + 1}"
+  memory   = 4096
+  vcpu     = 2
+
+  cpu {
+    mode = "host-passthrough"
+  }
+
+  disk {
+    volume_id = libvirt_volume.ceph_disk[count.index].id
+  }
+
+  network_interface {
+    network_name = "default"
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+    autoport    = true
+  }
+
+  cloudinit = libvirt_cloudinit_disk.ceph_cloudinit[count.index].id
+}
+
+# Declare the disksize variable
+variable "disksize" {
+  description = "The size of the disk for each VM in KB"
+  type        = number
+  default     = 41943040  # Default size for the disk
+}
+
+resource "libvirt_cloudinit_disk" "ceph_cloudinit" {
+  count     = 3
+  name      = "cloudinit-ceph${count.index + 1}"
+  pool      = "homelab_k8s"
+
+  user_data = <<EOF
+#cloud-config
+hostname: ceph${count.index + 1}
+manage_etc_hosts: true
+users:
+  - default
+  - name: arch
+    ssh-authorized-keys:
+      - ${var.ssh_key}
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    lock_passwd: false
+    passwd: "FunTimes2025!"
+    shell: /bin/bash
+
+runcmd:
+  - sudo pacman -S ssh --noconfirm
+  - sudo systemctl enable --now sshd
+  - sudo chmod 700 /home/arch/.ssh
+  - sudo chmod 600 /home/arch/.ssh/authorized_keys
+  - sudo chown -R arch:arch /home/arch/.ssh
+  - sudo pacman -S git htop btop 
+  - git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si
+  - yay -Syy
+
+EOF
+
+  network_config = <<EOF
+version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+EOF
+}

--- a/terraform/ceph/private.tfvars.tftpl
+++ b/terraform/ceph/private.tfvars.tftpl
@@ -1,0 +1,8 @@
+variable "ssh_key" {
+  type = string
+  default = ""
+}
+variable "vm_image" {
+  type = string
+  default = ""
+}

--- a/terraform/ceph/variables.tf
+++ b/terraform/ceph/variables.tf
@@ -1,0 +1,13 @@
+# variables.tf
+variable "ssh_key" {
+  description = "SSH key to add to the arch user"
+  type        = string
+  default     = SSH_PUB_KEY_HERE
+}
+
+variable "vm_image_path" {
+  description = "Path to the base image for the VM"
+  type        = string
+  default     = /path/to/cloudinit/os-image.qcow2"
+}
+

--- a/terraform/k8s/initial-post-create.sh
+++ b/terraform/k8s/initial-post-create.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+for vm in $(sudo virsh list --all|grep k8s|awk '{print $2}'); do sudo virsh shutdown $vm;done
+sleep 10
+echo "Waiting on shutdown"
+for vm in $(sudo virsh list --all|grep k8s|awk '{print $2}'); do sudo qemu-img resize /data/libvirt/images/homelab_k8s/$vm.qcow2 +40G && sudo virsh start $vm;done
+sleep 20
+echo "Waiting on SSH"
+for vm in $(sudo virsh list --all|grep k8s|awk '{print $2}'); do ssh -k -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null arch@$(sudo virsh domifaddr $vm|awk '{print $4}'|cut -d '/' -f1|grep -v 'Protocol\|^$') "sudo growpart /dev/vda 3 && sudo resize2fs /dev/vda3";done
+
+# after kube-init
+#for vm in $(sudo virsh list --all |grep k8s |grep worker |awk '{print $2}'; do kubectl label node $vm node-role.kubernetes.io/worker=;done

--- a/terraform/k8s/main.tf
+++ b/terraform/k8s/main.tf
@@ -1,0 +1,289 @@
+terraform {
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+# Base image for the VM
+resource "libvirt_volume" "base_arch_qcow2" {
+  name   = "base-arch.qcow2"
+  pool   = "homelab_k8s"
+  source = var.vm_image_path  # Path to the base image
+  format = "qcow2"
+}
+
+# Defining master nodes
+resource "libvirt_volume" "master_disk" {
+  count  = 3
+  name   = "master-k8s-${count.index + 1}.qcow2"
+  pool   = "homelab_k8s"
+  source = libvirt_volume.base_arch_qcow2.id
+  format = "qcow2"
+}
+# Define the master node using the new 50GB disk
+resource "libvirt_domain" "master_node" {
+  count    = 3
+  name     = "master-k8s-${count.index + 1}"
+  memory   = 4096
+  vcpu     = 2
+
+  cpu {
+    mode = "host-passthrough"
+  }
+
+  disk {
+    volume_id = libvirt_volume.master_disk[count.index].id
+  }
+
+  network_interface {
+    network_name = "default"
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+    autoport    = true
+  }
+
+  cloudinit = libvirt_cloudinit_disk.master_cloudinit[count.index].id
+}
+
+# Declare the disksize variable
+variable "disksize" {
+  description = "The size of the disk for each VM in GB"
+  type        = number
+  default     = 45097156608  # Default size for the disk
+}
+
+resource "libvirt_cloudinit_disk" "master_cloudinit" {
+  count     = 3
+  name      = "master-k8s-cloudinit-${count.index + 1}"
+  pool      = "homelab_k8s"
+
+  user_data = <<EOF
+#cloud-config
+hostname: master-k8s-${count.index + 1}
+manage_etc_hosts: true
+users:
+  - default
+  - name: arch
+    ssh-authorized-keys:
+      - ${var.ssh_key}
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    lock_passwd: false
+    passwd: "FunTimes2025!"
+    shell: /bin/bash
+
+runcmd:
+  - sudo swapoff -a
+  - sudo sed -i '/swap/s/^/#/' /etc/fstab
+  - sudo pacman-key --init 
+  - sudo pacman-key --populate archlinux
+  - sudo pacman -Syy --noconfirm
+  - sudo pacman -S ssh --noconfirm
+  - sudo systemctl enable --now sshd
+  - sudo chmod 700 /home/arch/.ssh
+  - sudo chmod 600 /home/arch/.ssh/authorized_keys
+  - sudo chown -R arch:arch /home/arch/.ssh
+  - sudo pacman -S plocate vim nfs-utils --noconfirm
+  - sudo pacman -R iptables iproute2 base dhclient cloud-init  --noconfirm
+  - sudo pacman -S kubeadm kubelet kubectl docker helm base dhclient cloud-init nfs-utils --noconfirm
+  - sudo modprobe br_netfilter
+  - sudo sysctl -p /etc/sysctl.d/50-kubelet.conf
+  - sudo systemctl enable --now docker kubelet
+  - helm repo add stable https://charts.helm.sh/stable
+EOF
+
+  network_config = <<EOF
+version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+EOF
+}
+#########################
+# Define 6 Worker Nodes
+#########################
+resource "libvirt_volume" "worker_disk" {
+  count  = 6
+  name   = "worker-k8s-${count.index + 1}.qcow2"
+  pool   = "homelab_k8s"
+  source = libvirt_volume.base_arch_qcow2.id
+  format = "qcow2"
+}
+
+resource "libvirt_domain" "worker_node" {
+  count  = 6
+  name   = "worker-k8s-${count.index + 1}"
+  memory = 4096
+  vcpu   = 2
+
+  cpu {
+    mode = "host-passthrough"
+  }
+  disk {
+    volume_id = libvirt_volume.worker_disk[count.index].id
+  }
+
+  network_interface {
+    network_name = "default"
+  }
+
+   console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+    autoport    = true
+  }
+
+  cloudinit = libvirt_cloudinit_disk.worker_cloudinit[count.index].id
+}
+
+resource "libvirt_cloudinit_disk" "worker_cloudinit" {
+  count     = 6
+  name      = "worker-k8s-cloudinit-${count.index + 1}"
+  pool      = "homelab_k8s"
+
+  user_data = <<EOF
+#cloud-config
+hostname: worker-k8s-${count.index + 1}
+manage_etc_hosts: true
+users:
+  - default
+  - name: arch
+    ssh-authorized-keys:
+      - ${var.ssh_key}
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+    lock_passwd: false
+    passwd: "FunTimes2025!"
+    shell: /bin/bash
+
+runcmd:
+  - sudo swapoff -a
+  - sudo sed -i '/swap/s/^/#/' /etc/fstab
+  - sudo pacman-key --init
+  - sudo pacman-key --populate archlinux
+  - sudo pacman -Syy --noconfirm
+  - sudo pacman -S ssh --noconfirm
+  - sudo systemctl enable --now sshd
+  - sudo chmod 700 /home/arch/.ssh
+  - sudo chmod 600 /home/arch/.ssh/authorized_keys
+  - sudo chown -R arch:arch /home/arch/.ssh
+  - sudo pacman -S plocate vim nfs-utils --noconfirm 
+  - sudo pacman -S kubeadm kubelet kubectl docker helm base dhclient cloud-init nfs-utils --noconfirm
+  - sudo modprobe br_netfilter
+  - sudo sysctl -p /etc/sysctl.d/50-kubelet.conf
+  - sudo systemctl enable --now docker kubelet
+EOF
+
+  network_config = <<EOF
+version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+EOF
+}
+
+######################################
+# Define Worker Nodes With Extra Ram
+######################################
+resource "libvirt_volume" "worker_RAM_disk" {
+  count  = 1
+  name   = "worker-k8s-RAM${count.index + 1}.qcow2"
+  pool   = "homelab_k8s"
+  source = libvirt_volume.base_arch_qcow2.id
+  format = "qcow2"
+}
+
+resource "libvirt_domain" "worker_node_RAM" {
+  count  = 1
+  name   = "worker-k8s-RAM${count.index + 1}"
+  memory = 24576
+  vcpu   = 4
+
+  cpu {
+    mode = "host-passthrough"
+  }
+  disk {
+    volume_id = libvirt_volume.worker_RAM_disk[count.index].id
+  }
+
+  network_interface {
+    network_name = "default"
+  }
+
+   console {
+    type        = "pty"
+    target_port = "0"
+  }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+    autoport    = true
+  }
+
+  cloudinit = libvirt_cloudinit_disk.worker_RAM_cloudinit_[count.index].id
+}
+
+resource "libvirt_cloudinit_disk" "worker_RAM_cloudinit_" {
+  count     = 1
+  name      = "worker-k8s-cloudinit-RAM${count.index + 1}"
+  pool      = "homelab_k8s"
+
+  user_data = <<EOF
+#cloud-config
+hostname: worker-k8s-ram${count.index + 1}
+manage_etc_hosts: true
+users:
+  - default
+  - name: arch
+    ssh-authorized-keys:
+      - ${var.ssh_key}
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    shell: /bin/bash
+    lock_passwd: false
+    passwd: "FunTimes2025!"
+    shell: /bin/bash
+
+runcmd:
+  - sudo swapoff -a
+  - sudo sed -i '/swap/s/^/#/' /etc/fstab
+  - sudo pacman-key --init
+  - sudo pacman-key --populate archlinux
+  - sudo pacman -Syy --noconfirm
+  - sudo pacman -S ssh --noconfirm
+  - sudo systemctl enable --now sshd
+  - sudo chmod 700 /home/arch/.ssh
+  - sudo chmod 600 /home/arch/.ssh/authorized_keys
+  - sudo chown -R arch:arch /home/arch/.ssh
+  - sudo pacman -S plocate vim nfs-utils --noconfirm 
+  - sudo pacman -S kubeadm kubelet kubectl docker helm base dhclient cloud-init nfs-utils --noconfirm
+  - sudo modprobe br_netfilter
+  - sudo sysctl -p /etc/sysctl.d/50-kubelet.conf
+  - sudo systemctl enable --now docker kubelet
+EOF
+
+  network_config = <<EOF
+version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+EOF
+}

--- a/terraform/k8s/private.tfvars.tftpl
+++ b/terraform/k8s/private.tfvars.tftpl
@@ -1,0 +1,8 @@
+variable "ssh_key" {
+  type = string
+  default = ""
+}
+variable "vm_image" {
+  type = string
+  default = ""
+}

--- a/terraform/k8s/variables.tf
+++ b/terraform/k8s/variables.tf
@@ -1,0 +1,13 @@
+# variables.tf
+variable "ssh_key" {
+  description = "SSH key to add to the arch user"
+  type        = string
+  default     = SSH_PUB_KEY_HERE
+}
+
+variable "vm_image_path" {
+  description = "Path to the base image for the VM"
+  type        = string
+  default     = /path/to/cloudinit/os-image.qcow2"
+}
+


### PR DESCRIPTION
…tes applications and infrastructure

- Added Kubernetes application manifests for:
  - n8n
  - Ollama
  - PathfinderWiki (MediaWiki with nginx, php-fpm, MariaDB)
  - Vaultwarden

- Added infrastructure configurations for:
  - Cilium (CNI)
  - Longhorn (storage)
  - Traefik (Ingress)
  - Cert-manager (certificates)

- Added Terraform configurations for:
  - Kubernetes cluster provisioning
  - Ceph deployment

- Updated README.md with infrastructure details and future enhancements

- Updated .gitignore to exclude unnecessary files