### PR TITLE
feat(n8n): encryption key via secret instead of random generated ever…

### DIFF
--- a/apps/base/n8n/base/03-deployment.yaml
+++ b/apps/base/n8n/base/03-deployment.yaml
@@ -46,6 +46,11 @@ spec:
                 secretKeyRef:
                   name: postgres-secret
                   key: POSTGRES_NON_ROOT_PASSWORD
+            - name: N8N_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: n8n-secret
+                  key: N8N_ENCRYPTION_KEY
             - name: N8N_PROTOCOL
               value: http
             - name: N8N_PORT


### PR DESCRIPTION
Using a K8S secret definition for n8n's encryption key to prevent each recreate of n8n pods to have a different encryption key