### PR TITLE
feat: n8n python docs

### DIFF
--- a/apps/base/n8n/python-docs/00-python-docs-pv.yaml
+++ b/apps/base/n8n/python-docs/00-python-docs-pv.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: python-docs
+  namespace: n8n
+spec:
+  capacity:
+    storage: 20Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: python-docs
+  nfs:
+    path: /data/nfs/n8n/python-docs/
+    server: 192.168.122.1
+  mountOptions:
+    - hard
+    - nfsvers=4.1

--- a/apps/base/n8n/python-docs/01-python-docs-pvc.yaml
+++ b/apps/base/n8n/python-docs/01-python-docs-pvc.yaml
@@ -1,0 +1,14 @@
+---
+# PVC for wiki content (if not already created)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: python-docs
+  namespace: n8n
+spec:
+  storageClassName: python-docs
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 20Gi

--- a/apps/base/n8n/python-docs/02-nginx-configmap.yaml
+++ b/apps/base/n8n/python-docs/02-nginx-configmap.yaml
@@ -1,0 +1,32 @@
+---
+# ConfigMap for nginx.conf
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pathfinderwiki-nginx-config
+  namespace: pathfinderwiki
+data:
+  nginx.conf: |
+    user nginx;
+    worker_processes auto;
+    pid /run/nginx.pid;
+    include /etc/nginx/modules-enabled/*.conf;
+    events {
+      worker_connections 768;
+    }
+    http {
+      gzip on;
+      server_tokens off;
+
+      server {
+        listen 80;
+        server_name _default;
+        root /data;
+        index index.php;
+        try_files $uri $uri/ =404;
+
+        location /healthz {
+          return 200;
+        }
+      }
+    }

--- a/apps/base/n8n/python-docs/02-nginx-configmap.yaml
+++ b/apps/base/n8n/python-docs/02-nginx-configmap.yaml
@@ -3,8 +3,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: pathfinderwiki-nginx-config
-  namespace: pathfinderwiki
+  name: python-docs-config
+  namespace: n8n
 data:
   nginx.conf: |
     user nginx;

--- a/apps/base/n8n/python-docs/02-nginx-configmap.yaml
+++ b/apps/base/n8n/python-docs/02-nginx-configmap.yaml
@@ -21,7 +21,7 @@ data:
       server {
         listen 80;
         server_name _default;
-        root /data;
+        root /usr/share/nginx/html/;
         index index.php;
         try_files $uri $uri/ =404;
 

--- a/apps/base/n8n/python-docs/03-deployment.yaml
+++ b/apps/base/n8n/python-docs/03-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: python-docs-deployment
+  name: python-docs
   namespace: n8n
 spec:
   replicas: 1
@@ -18,7 +18,7 @@ spec:
           image: nginx:latest
           volumeMounts:
             - name: python-docs-volume
-              mountPath: /data
+              mountPath: /usr/share/nginx/html
             - name: nginx-config
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf

--- a/apps/base/n8n/python-docs/03-deployment.yaml
+++ b/apps/base/n8n/python-docs/03-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: python-docs-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: python-docs
+  template:
+    metadata:
+      labels:
+        app: python-docs
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:latest
+          volumeMounts:
+            - name: python-docs-volume
+              mountPath: /data
+          ports:
+            - containerPort: 80
+      volumes:
+        - name: python-docs-volume
+          persistentVolumeClaim:
+            claimName: python-docs  # PVC reference

--- a/apps/base/n8n/python-docs/03-deployment.yaml
+++ b/apps/base/n8n/python-docs/03-deployment.yaml
@@ -30,4 +30,4 @@ spec:
             claimName: python-docs  # PVC reference
         - name: nginx-config
           configMap:
-            name: pathfinderwiki-nginx-config
+            name: python-docs-config

--- a/apps/base/n8n/python-docs/03-deployment.yaml
+++ b/apps/base/n8n/python-docs/03-deployment.yaml
@@ -24,3 +24,6 @@ spec:
         - name: python-docs-volume
           persistentVolumeClaim:
             claimName: python-docs  # PVC reference
+        - name: nginx-config
+          configMap:
+            name: pathfinderwiki-nginx-config

--- a/apps/base/n8n/python-docs/03-deployment.yaml
+++ b/apps/base/n8n/python-docs/03-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: python-docs-deployment
+  namespace: n8n
 spec:
   replicas: 1
   selector:
@@ -18,6 +19,9 @@ spec:
           volumeMounts:
             - name: python-docs-volume
               mountPath: /data
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
           ports:
             - containerPort: 80
       volumes:

--- a/apps/base/n8n/python-docs/04-service.yaml
+++ b/apps/base/n8n/python-docs/04-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: python-docs-service
+spec:
+  selector:
+    app: python-docs
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP

--- a/apps/base/n8n/python-docs/04-service.yaml
+++ b/apps/base/n8n/python-docs/04-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: python-docs-service
+  namespace: n8n
 spec:
   selector:
     app: python-docs


### PR DESCRIPTION
A small webserver container which contains all python documentation as text files on a NFS share and allows them to be consumed by n8n